### PR TITLE
Fix TM_FILENAME_BASE

### DIFF
--- a/autoload/vsnip/session/snippet/node/variable.vim
+++ b/autoload/vsnip/session/snippet/node/variable.vim
@@ -47,7 +47,7 @@ function! s:Variable.resolve() abort
     return expand('%:p:t')
 
   elseif self.name ==# 'TM_FILENAME_BASE'
-    return substitute(expand('%:p:t'), '\..*$', '', 'g')
+    return substitute(expand('%:p:t'), '^\@<!\..*$', '', '')
 
   elseif self.name ==# 'TM_DIRECTORY'
     return expand('%:p:h:t')


### PR DESCRIPTION
Fix that if the filename starts with dot (e.g. `.vimrc`), `TM_FILENAME_BASE` becomes an empty string.