### PR TITLE
Fix(source.vim): Fix undefined error while snippet is empty

### DIFF
--- a/autoload/vsnip/source.vim
+++ b/autoload/vsnip/source.vim
@@ -30,6 +30,7 @@ function! vsnip#source#create(path) abort
       throw printf('%s is not valid json.', a:path)
     endif
   catch /.*/
+    let l:json = {}
     echomsg printf('Parsing error occurred on: %s', a:path)
     echomsg string({ 'exception': v:exception, 'throwpint': v:throwpoint })
   endtry


### PR DESCRIPTION
This causes because l:json must be used after error-handling, but
catching doesn't declare.