### PR TITLE
Fix variable

### DIFF
--- a/autoload/vsnip/session/snippet.vim
+++ b/autoload/vsnip/session/snippet.vim
@@ -173,12 +173,12 @@ function! s:Snippet.sync() abort
       endif
 
       " variable placeholder
-      if type(a:node.id) == 1 && !has_key(self.variable_placeholder, a:node.id)
+      if type(a:node.id) == type('') && !has_key(self.variable_placeholder, a:node.id)
         let self.variable_placeholder[a:node.id] = len(self.variable_placeholder) + 1
         let a:node.id = s:max_tabstop - self.variable_placeholder[a:node.id]
         let self.group[a:node.id] =  a:node
 
-      elseif type(a:node.id) == 1
+      elseif type(a:node.id) == type('')
         let a:node.id = s:max_tabstop - self.variable_placeholder[a:node.id]
         let a:node.follower = v:true
         let a:node.children = [vsnip#session#snippet#node#create_text(self.group[a:node.id].text())]

--- a/autoload/vsnip/session/snippet.vim
+++ b/autoload/vsnip/session/snippet.vim
@@ -164,6 +164,7 @@ function! s:Snippet.sync() abort
   let l:fn2.self = self
   let l:fn2.found_final_tabstop = v:false
   let l:fn2.group = {}
+  let l:fn2.variable_placeholder = {}
   function! l:fn2.traverse(range, node, parent, depth) abort
     if a:node.type ==# 'placeholder'
       " append text node when placeholder has no children.
@@ -171,8 +172,19 @@ function! s:Snippet.sync() abort
         let a:node.children = [vsnip#session#snippet#node#create_text('')]
       endif
 
+      " variable placeholder
+      if type(a:node.id) == 1 && !has_key(self.variable_placeholder, a:node.id)
+        let self.variable_placeholder[a:node.id] = len(self.variable_placeholder) + 1
+        let a:node.id = s:max_tabstop - self.variable_placeholder[a:node.id]
+        let self.group[a:node.id] =  a:node
+
+      elseif type(a:node.id) == 1
+        let a:node.id = s:max_tabstop - self.variable_placeholder[a:node.id]
+        let a:node.follower = v:true
+        let a:node.children = [vsnip#session#snippet#node#create_text(self.group[a:node.id].text())]
+
       " sync same tabstop placeholders.
-      if !has_key(self.group, a:node.id)
+      elseif !has_key(self.group, a:node.id)
         " first occurrence.
         let self.group[a:node.id] = a:node
       else

--- a/autoload/vsnip/session/snippet.vim
+++ b/autoload/vsnip/session/snippet.vim
@@ -195,15 +195,15 @@ function! s:Snippet.sync() abort
         let a:node.choice = []
 
         if !has_key(self.variable_placeholder, a:node.name)
-          let self.variable_placeholder[a:node.name] = len(self.variable_placeholder) + 1
-          let a:node.id = s:max_tabstop - self.variable_placeholder[a:node.name]
+          let self.variable_placeholder[a:node.name] = s:max_tabstop - (len(self.variable_placeholder) + 1)
+          let a:node.id = self.variable_placeholder[a:node.name]
           let a:node.follower = v:false
           let a:node.children = empty(a:node.children) ?
                 \ [vsnip#session#snippet#node#create_text(a:node.name)] :
                 \ a:node.children
           let self.group[a:node.id] =  a:node
         else
-          let a:node.id = s:max_tabstop - self.variable_placeholder[a:node.name]
+          let a:node.id = self.variable_placeholder[a:node.name]
           let a:node.follower = v:true
           let a:node.children = [vsnip#session#snippet#node#create_text(self.group[a:node.id].text())]
         endif

--- a/autoload/vsnip/session/snippet.vimspec
+++ b/autoload/vsnip/session/snippet.vimspec
@@ -134,6 +134,11 @@ Describe vsnip#snippet
       call l:snippet.sync()
       call s:expect(l:snippet.text()).to_equal('console.log(___ult, ___ult)')
     End
+
+    It Should sync known variable
+      let l:snippet = s:Snippet.new(s:start_position, 'console.log(${CURRENT_YEAR})')
+      call s:expect(l:snippet.text()).to_equal('console.log(' . strftime('%Y') . ')')
+    End
   End
 
   Describe #text

--- a/autoload/vsnip/session/snippet.vimspec
+++ b/autoload/vsnip/session/snippet.vimspec
@@ -367,4 +367,3 @@ Describe vsnip#snippet
   End
 
 End
-

--- a/autoload/vsnip/session/snippet.vimspec
+++ b/autoload/vsnip/session/snippet.vimspec
@@ -111,6 +111,29 @@ Describe vsnip#snippet
       call s:expect(l:snippet.text()).to_equal('console.log(___ult, ___ult)')
     End
 
+    It Should sync variable placeholder 1
+      let l:snippet = s:Snippet.new(s:start_position, 'console.log(${variable:default}, $variable)')
+      call s:expect(l:snippet.text()).to_equal('console.log(default, default)')
+    End
+
+    It Should sync variable placeholder 2
+      let l:snippet = s:Snippet.new(s:start_position, 'console.log(${variable:default}, $variable)')
+      call l:snippet.follow(0, {
+            \   'range': {
+            \     'start': {
+            \       'line': 1,
+            \       'character': 13
+            \     },
+            \     'end': {
+            \       'line': 1,
+            \       'character': 17
+            \     }
+            \   },
+            \   'text': '___'
+            \ })
+      call l:snippet.sync()
+      call s:expect(l:snippet.text()).to_equal('console.log(___ult, ___ult)')
+    End
   End
 
   Describe #text

--- a/autoload/vsnip/session/snippet/node/placeholder.vim
+++ b/autoload/vsnip/session/snippet/node/placeholder.vim
@@ -23,4 +23,3 @@ endfunction
 function! s:Placeholder.text() abort
   return join(map(copy(self.children), { k, v -> v.text() }), '')
 endfunction
-

--- a/autoload/vsnip/session/snippet/node/variable.vim
+++ b/autoload/vsnip/session/snippet/node/variable.vim
@@ -104,6 +104,10 @@ function! s:Variable.resolve() abort
     return '//' " TODO
   endif
 
-  return join(map(copy(self.children), { k, v -> v.text() }), '')
+  if len(self.children) != 0
+    return join(map(copy(self.children), { k, v -> v.text() }), '')
+  endif
+
+  return self.name
 endfunction
 

--- a/autoload/vsnip/session/snippet/node/variable.vim
+++ b/autoload/vsnip/session/snippet/node/variable.vim
@@ -3,39 +3,41 @@ function! vsnip#session#snippet#node#variable#import() abort
 endfunction
 
 let s:Variable = {}
-let s:known_variables = [
-      \   'TM_SELECTED_TEXT',
-      \   'TM_CURRENT_LINE',
-      \   'TM_CURRENT_WORD',
-      \   'TM_LINE_INDEX',
-      \   'TM_LINE_NUMBER',
-      \   'TM_FILENAME',
-      \   'TM_FILENAME_BASE',
-      \   'TM_DIRECTORY',
-      \   'TM_FILEPATH',
-      \   'CLIPBOARD',
-      \   'WORKSPACE_NAME',
-      \   'CURRENT_YEAR',
-      \   'CURRENT_YEAR_SHORT',
-      \   'CURRENT_MONTH',
-      \   'CURRENT_MONTH_NAME',
-      \   'CURRENT_MONTH_NAME_SHORT',
-      \   'CURRENT_DATE',
-      \   'CURRENT_DAY_NAME',
-      \   'CURRENT_DAY_NAME_SHORT',
-      \   'CURRENT_HOUR',
-      \   'CURRENT_MINUTE',
-      \   'CURRENT_SECOND',
-      \   'BLOCK_COMMENT_START',
-      \   'BLOCK_COMMENT_END',
-      \   'LINE_COMMENT',
-      \ ]
+  " @see https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables
+" TODO: BLOCK_COMMENT_START, BLOCK_COMMENT_END, LINE_COMMENT
+let s:known_variables = {
+      \   'TM_SELECTED_TEXT': { -> vsnip#selected_text()},
+      \   'TM_CURRENT_LINE': { -> getline('.')},
+      \   'TM_CURRENT_WORD': { -> ''},
+      \   'TM_LINE_INDEX': { -> line('.') - 1},
+      \   'TM_LINE_NUMBER': { -> line('.')},
+      \   'TM_FILENAME': { -> expand('%:p:t')},
+      \   'TM_FILENAME_BASE': { -> substitute(expand('%:p:t'), '^\@<!\..*$', '', '')},
+      \   'TM_DIRECTORY': { -> expand('%:p:h:t')},
+      \   'TM_FILEPATH': { -> expand('%:p')},
+      \   'CLIPBOARD': { -> getreg(v:register)},
+      \   'WORKSPACE_NAME': { -> ''},
+      \   'CURRENT_YEAR': { -> strftime('%Y')},
+      \   'CURRENT_YEAR_SHORT': { -> strftime('%y')},
+      \   'CURRENT_MONTH': { -> strftime('%m')},
+      \   'CURRENT_MONTH_NAME': { -> strftime('%B')},
+      \   'CURRENT_MONTH_NAME_SHORT': { -> strftime('%b')},
+      \   'CURRENT_DATE': { -> strftime('%d')},
+      \   'CURRENT_DAY_NAME': { -> strftime('%A')},
+      \   'CURRENT_DAY_NAME_SHORT': { -> strftime('%a')},
+      \   'CURRENT_HOUR': { -> strftime('%H')},
+      \   'CURRENT_MINUTE': { -> strftime('%M')},
+      \   'CURRENT_SECOND': { -> strftime('%S')},
+      \   'BLOCK_COMMENT_START': { -> '/**'},
+      \   'BLOCK_COMMENT_END': { -> '*/'},
+      \   'LINE_COMMENT': { -> '//'},
+      \ }
 
 "
 " new.
 "
 function! s:Variable.new(ast) abort
-  if index(s:known_variables, a:ast.name) >= 0
+  if has_key(s:known_variables, a:ast.name)
     return extend(deepcopy(s:Variable), {
           \   'type': 'variable',
           \   'name': a:ast.name,
@@ -66,81 +68,8 @@ endfunction
 " resolve.
 "
 function! s:Variable.resolve() abort
-  " @see https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables
-  if self.name ==# 'TM_SELECTED_TEXT'
-    return vsnip#selected_text()
-
-  elseif self.name ==# 'TM_CURRENT_LINE'
-    return getline('.')
-
-  elseif self.name ==# 'TM_CURRENT_WORD'
-    return ''
-
-  elseif self.name ==# 'TM_LINE_INDEX'
-    return line('.') - 1
-
-  elseif self.name ==# 'TM_LINE_NUMBER'
-    return line('.')
-
-  elseif self.name ==# 'TM_FILENAME'
-    return expand('%:p:t')
-
-  elseif self.name ==# 'TM_FILENAME_BASE'
-    return substitute(expand('%:p:t'), '^\@<!\..*$', '', '')
-
-  elseif self.name ==# 'TM_DIRECTORY'
-    return expand('%:p:h:t')
-
-  elseif self.name ==# 'TM_FILEPATH'
-    return expand('%:p')
-
-  elseif self.name ==# 'CLIPBOARD'
-    return getreg(v:register)
-
-  elseif self.name ==# 'WORKSPACE_NAME'
-    return ''
-
-  elseif self.name ==# 'CURRENT_YEAR'
-    return strftime('%Y')
-
-  elseif self.name ==# 'CURRENT_YEAR_SHORT'
-    return strftime('%y')
-
-  elseif self.name ==# 'CURRENT_MONTH'
-    return strftime('%m')
-
-  elseif self.name ==# 'CURRENT_MONTH_NAME'
-    return strftime('%B')
-
-  elseif self.name ==# 'CURRENT_MONTH_NAME_SHORT'
-    return strftime('%b')
-
-  elseif self.name ==# 'CURRENT_DATE'
-    return strftime('%d')
-
-  elseif self.name ==# 'CURRENT_DAY_NAME'
-    return strftime('%A')
-
-  elseif self.name ==# 'CURRENT_DAY_NAME_SHORT'
-    return strftime('%a')
-
-  elseif self.name ==# 'CURRENT_HOUR'
-    return strftime('%H')
-
-  elseif self.name ==# 'CURRENT_MINUTE'
-    return strftime('%M')
-
-  elseif self.name ==# 'CURRENT_SECOND'
-    return strftime('%S')
-
-  elseif self.name ==# 'BLOCK_COMMENT_START'
-    return '/**' " TODO
-
-  elseif self.name ==# 'BLOCK_COMMENT_END'
-    return '*/' " TODO
-
-  elseif self.name ==# 'LINE_COMMENT'
-    return '//' " TODO
+  if has_key(s:known_variables, self.name)
+    return s:known_variables[self.name]()
   endif
 
   return join(map(copy(self.children), { k, v -> v.text() }), '')

--- a/autoload/vsnip/session/snippet/node/variable.vim
+++ b/autoload/vsnip/session/snippet/node/variable.vim
@@ -44,16 +44,16 @@ function! s:Variable.new(ast) abort
           \   'children': vsnip#session#snippet#node#create_from_ast(get(a:ast, 'children', [])),
           \ })
   endif
+
+  let l:children = has_key(a:ast, 'children') ?
+        \ vsnip#session#snippet#node#create_from_ast(a:ast.children) :
+        \ [vsnip#session#snippet#node#create_text(a:ast.name)]
   return extend(deepcopy(vsnip#session#snippet#node#placeholder#import()), {
         \   'type': 'placeholder',
         \   'id': a:ast.name,
         \   'follower': v:false,
         \   'choice': [],
-        \   'children': vsnip#session#snippet#node#create_from_ast(get(a:ast, 'children', [{
-        \     'type': 'text',
-        \     'raw': a:ast.name,
-        \     'escaped': a:ast.name,
-        \   }])),
+        \   'children': l:children,
         \ })
 endfunction
 

--- a/autoload/vsnip/session/snippet/node/variable.vim
+++ b/autoload/vsnip/session/snippet/node/variable.vim
@@ -3,7 +3,7 @@ function! vsnip#session#snippet#node#variable#import() abort
 endfunction
 
 let s:Variable = {}
-  " @see https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables
+" @see https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables
 " TODO: BLOCK_COMMENT_START, BLOCK_COMMENT_END, LINE_COMMENT
 let s:known_variables = {
       \   'TM_SELECTED_TEXT': { -> vsnip#selected_text()},
@@ -45,6 +45,8 @@ function! s:Variable.new(ast) abort
           \ })
   endif
 
+  " When a variable is unknown (that is, its name isn't defined) the name of the variable is inserted and it is transformed into a placeholder.
+  " @see https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables
   let l:children = has_key(a:ast, 'children') ?
         \ vsnip#session#snippet#node#create_from_ast(a:ast.children) :
         \ [vsnip#session#snippet#node#create_text(a:ast.name)]

--- a/autoload/vsnip/session/snippet/node/variable.vim
+++ b/autoload/vsnip/session/snippet/node/variable.vim
@@ -37,25 +37,11 @@ let s:known_variables = {
 " new.
 "
 function! s:Variable.new(ast) abort
-  if has_key(s:known_variables, a:ast.name)
-    return extend(deepcopy(s:Variable), {
-          \   'type': 'variable',
-          \   'name': a:ast.name,
-          \   'children': vsnip#session#snippet#node#create_from_ast(get(a:ast, 'children', [])),
-          \ })
-  endif
-
-  " When a variable is unknown (that is, its name isn't defined) the name of the variable is inserted and it is transformed into a placeholder.
-  " @see https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables
-  let l:children = has_key(a:ast, 'children') ?
-        \ vsnip#session#snippet#node#create_from_ast(a:ast.children) :
-        \ [vsnip#session#snippet#node#create_text(a:ast.name)]
-  return extend(deepcopy(vsnip#session#snippet#node#placeholder#import()), {
-        \   'type': 'placeholder',
-        \   'id': a:ast.name,
-        \   'follower': v:false,
-        \   'choice': [],
-        \   'children': l:children,
+  return extend(deepcopy(s:Variable), {
+        \   'type': 'variable',
+        \   'name': a:ast.name,
+        \   'unknown': !has_key(s:known_variables, a:ast.name),
+        \   'children': vsnip#session#snippet#node#create_from_ast(get(a:ast, 'children', [])),
         \ })
 endfunction
 
@@ -76,4 +62,3 @@ function! s:Variable.resolve() abort
 
   return join(map(copy(self.children), { k, v -> v.text() }), '')
 endfunction
-

--- a/autoload/vsnip/session/snippet/parser.vim
+++ b/autoload/vsnip/session/snippet/parser.vim
@@ -133,9 +133,6 @@ let s:variable2 = s:map(s:seq(s:dollar, s:open, s:varname, s:close), { value -> 
       \   'type': 'variable',
       \   'name': value[2]
       \ } })
-
-" Can't understand this, So currently unsupport.
-
 let s:variable3 = s:map(s:seq(
       \   s:dollar,
       \   s:open,
@@ -148,7 +145,6 @@ let s:variable3 = s:map(s:seq(
       \   'name': value[2],
       \   'children': [value[4]]
       \ } })
-
 let s:variable4 = s:map(s:seq(s:dollar, s:open, s:varname, s:transform, s:close), { value -> {
       \   'type': 'variable',
       \   'name': value[2],
@@ -218,4 +214,3 @@ let s:choice = s:map(s:seq(
 " parser.
 "
 let s:parser = s:many(s:or(s:any, s:text(['$'])))
-

--- a/autoload/vsnip/session/snippet/parser.vim
+++ b/autoload/vsnip/session/snippet/parser.vim
@@ -155,7 +155,20 @@ let s:variable4 = s:map(s:seq(s:dollar, s:open, s:varname, s:transform, s:close)
       \   'transform': value[3]
       \ } })
 
-let s:variable = s:or(s:variable1, s:variable2, s:variable4)
+let s:variable5 = s:map(s:seq(
+      \   s:dollar,
+      \   s:open,
+      \   s:varname,
+      \   s:colon,
+      \   s:many(s:or(s:any, s:text(['$', '}']))),
+      \   s:close
+      \ ), { value -> {
+      \   'type': 'variable',
+      \   'name': value[2],
+      \   'children': value[4]
+      \} })
+
+let s:variable = s:or(s:variable1, s:variable2, s:variable4, s:variable5)
 
 "
 " placeholder.

--- a/autoload/vsnip/session/snippet/parser.vim
+++ b/autoload/vsnip/session/snippet/parser.vim
@@ -135,19 +135,19 @@ let s:variable2 = s:map(s:seq(s:dollar, s:open, s:varname, s:close), { value -> 
       \ } })
 
 " Can't understand this, So currently unsupport.
-"
-" let s:variable3 = s:map(s:seq(
-"       \   s:dollar,
-"       \   s:open,
-"       \   s:varname,
-"       \   s:colon,
-"       \   s:or(s:any, s:text(['$', '}'])),
-"       \   s:close
-"       \ ), { value -> {
-"       \   'type': 'variable',
-"       \   'name': value[2],
-"       \   'children': value[4]
-"       \ } })
+
+let s:variable3 = s:map(s:seq(
+      \   s:dollar,
+      \   s:open,
+      \   s:varname,
+      \   s:colon,
+      \   s:or(s:any, s:text(['$', '}'])),
+      \   s:close
+      \ ), { value -> {
+      \   'type': 'variable',
+      \   'name': value[2],
+      \   'children': [value[4]]
+      \ } })
 
 let s:variable4 = s:map(s:seq(s:dollar, s:open, s:varname, s:transform, s:close), { value -> {
       \   'type': 'variable',
@@ -155,20 +155,7 @@ let s:variable4 = s:map(s:seq(s:dollar, s:open, s:varname, s:transform, s:close)
       \   'transform': value[3]
       \ } })
 
-let s:variable5 = s:map(s:seq(
-      \   s:dollar,
-      \   s:open,
-      \   s:varname,
-      \   s:colon,
-      \   s:many(s:or(s:any, s:text(['$', '}']))),
-      \   s:close
-      \ ), { value -> {
-      \   'type': 'variable',
-      \   'name': value[2],
-      \   'children': value[4]
-      \} })
-
-let s:variable = s:or(s:variable1, s:variable2, s:variable4, s:variable5)
+let s:variable = s:or(s:variable1, s:variable2, s:variable3, s:variable4)
 
 "
 " placeholder.

--- a/autoload/vsnip/session/snippet/parser.vimspec
+++ b/autoload/vsnip/session/snippet/parser.vimspec
@@ -150,6 +150,20 @@ Describe vsnip#session#snippet#parser
             \ })
     End
 
+    It Should parse variable
+      let l:parsed = vsnip#session#snippet#parser#parse('${variable:default}')
+      call s:expect(len(l:parsed)).to_equal(1)
+      call s:expect(l:parsed[0]).to_equal({
+            \   'type': 'variable',
+            \   'name': 'variable',
+            \   'children': [{
+            \     'type': 'text',
+            \     'raw': 'default',
+            \     'escaped': 'default',
+            \   }]
+            \ })
+    End
+
   End
 
 End


### PR DESCRIPTION
Hi @hrsh7th .

I used [c++ snippet that includes variable placeholder](https://github.com/one-harsh/vscode-cpp-snippets/blob/master/snippets/cpp.json#L2-L11). But, It looks something wrong...

In LSP definition, 

> When a variable is unknown (that is, its name isn't defined) the name of the variable is inserted and it is transformed into a placeholder.

So, I changed variable to placeholder when it's name is unkown.
There are two videos for the following snippet.

```json
{
    "for": {
		"prefix": "for",
		"body": [
			"for (${size_t} ${i} = ${1:0}; ${i} < ${2:length}; ${i}++)",
			"{",
			"	$3",
			"}"
		],
		"description": "Code snippet for 'for' loop"
	}
}
```

Before:

![before](https://user-images.githubusercontent.com/21323222/81378429-3fa70180-9142-11ea-9a9c-9e3e47eb78cf.gif)

After:

![after](https://user-images.githubusercontent.com/21323222/81378442-4766a600-9142-11ea-8ade-ea177b86994f.gif)
