### PR TITLE
Add visual mode mapping to set selection as $TM_SELECTED_TEXT

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ imap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab
 smap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
 imap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
 smap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
+" Save current visual selection to use as $TM_SELECTED_TEXT in the next snippet
+xmap         <C-l>  <Plug>(vsnip-set-selected-text)
 ```
 
 ### 3. Create your own snippet

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ smap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab
 imap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
 smap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
 " Save current visual selection to use as $TM_SELECTED_TEXT in the next snippet
+" See https://github.com/hrsh7th/vim-vsnip/pull/50
 xmap         <C-l>  <Plug>(vsnip-set-selected-text)
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ imap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-T
 smap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
 " Select text to use as $TM_SELECTED_TEXT in the next snippet.
 " See https://github.com/hrsh7th/vim-vsnip/pull/50
+" These mappings will behave like normal `c`. They select the text, remove it
+" and place you in insert mode.
+nmap        <C-j>   <Plug>(vsnip-cut-text)
+xmap        <C-j>   <Plug>(vsnip-cut-text)
+smap        <C-j>   <Plug>(vsnip-cut-text)
+" This will select the text and your in the exact same mode as before.
 nmap        <C-l>   <Plug>(vsnip-select-text)
 xmap        <C-l>   <Plug>(vsnip-select-text)
 smap        <C-l>   <Plug>(vsnip-select-text)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ NeoBundle 'hrsh7th/vim-vsnip-integ'
 ```viml
 " You can use other key to expand snippet.
 imap <expr> <C-j>   vsnip#available(1)  ? '<Plug>(vsnip-expand)'         : '<C-j>'
+" Expand selected placeholder with <C-j>
+smap <expr> <C-j>   vsnip#expandable()  ? '<Plug>(vsnip-expand)'         : '<C-j>'
 imap <expr> <C-l>   vsnip#available(1)  ? '<Plug>(vsnip-expand-or-jump)' : '<C-l>'
+" Jump to the next placeholder with <C-l>
 smap <expr> <C-l>   vsnip#available(1)  ? '<Plug>(vsnip-expand-or-jump)' : '<C-l>'
 imap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
 smap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'

--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ imap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab
 smap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
 imap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
 smap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
-" Save current visual selection to use as $TM_SELECTED_TEXT in the next snippet
+" Select text to use as $TM_SELECTED_TEXT in the next snippet.
 " See https://github.com/hrsh7th/vim-vsnip/pull/50
-xmap         <C-l>  <Plug>(vsnip-set-selected-text)
+nmap        <C-l>   <Plug>(vsnip-select-text)
+xmap        <C-l>   <Plug>(vsnip-select-text)
+smap        <C-l>   <Plug>(vsnip-select-text)
 ```
 
 ### 3. Create your own snippet

--- a/autoload/vsnip.vim
+++ b/autoload/vsnip.vim
@@ -21,9 +21,16 @@ endfunction
 "
 function! vsnip#available(...) abort
   let l:direction = get(a:000, 0, 1)
-  let l:expandable = !empty(vsnip#get_context())
+  let l:expandable = vsnip#expandable()
   let l:jumpable = !empty(s:session) && s:session.jumpable(l:direction)
   return l:expandable || l:jumpable
+endfunction
+
+"
+" vsnip#expandable.
+"
+function! vsnip#expandable() abort
+  return !empty(vsnip#get_context())
 endfunction
 
 "

--- a/doc/vsnip.txt
+++ b/doc/vsnip.txt
@@ -109,6 +109,9 @@ The below example uses '<Tab>' key.
   smap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
   imap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
   smap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
+  nmap        <C-j>   <Plug>(vsnip-cut-text)
+  xmap        <C-j>   <Plug>(vsnip-cut-text)
+  smap        <C-j>   <Plug>(vsnip-cut-text)
   nmap        <C-l>   <Plug>(vsnip-select-text)
   xmap        <C-l>   <Plug>(vsnip-select-text)
   smap        <C-l>   <Plug>(vsnip-select-text)

--- a/doc/vsnip.txt
+++ b/doc/vsnip.txt
@@ -109,6 +109,9 @@ The below example uses '<Tab>' key.
   smap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
   imap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
   smap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
+  nmap        <C-l>   <Plug>(vsnip-select-text)
+  xmap        <C-l>   <Plug>(vsnip-select-text)
+  smap        <C-l>   <Plug>(vsnip-select-text)
 <
 
 

--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -112,7 +112,7 @@ function! s:get_visual_text(type) abort
   else
     return
   endif
-  call vsnip#selected_text(@v)
+  call vsnip#selected_text(substitute(@v, '\n$', '', ''))
   let @v = reg_v
 endfunction
 

--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -96,24 +96,43 @@ endfunction
 "
 " <Plug>(vsnip-select-text)
 "
-nnoremap <silent> <Plug>(vsnip-select-text) :set operatorfunc=<SID>get_visual_text<CR>g@
-snoremap <silent> <Plug>(vsnip-select-text) <C-g>:<C-u>call <SID>get_visual_text(visualmode())<CR>gv<C-g>
-xnoremap <silent> <Plug>(vsnip-select-text) :<C-u>call <SID>get_visual_text(visualmode())<CR>gv
-function! s:get_visual_text(type) abort
+nnoremap <silent> <Plug>(vsnip-select-text) :set operatorfunc=<SID>vsnip_select_text_normal<CR>g@
+snoremap <silent> <Plug>(vsnip-select-text) <C-g>:<C-u>call <SID>vsnip_visual_text(visualmode())<CR>gv<C-g>
+xnoremap <silent> <Plug>(vsnip-select-text) :<C-u>call <SID>vsnip_visual_text(visualmode())<CR>gv
+function! s:vsnip_select_text_normal(type) abort
+  call s:vsnip_set_text(a:type, 'y')
+endfunction
+
+"
+" <Plug>(vsnip-cut-text)
+"
+nnoremap <silent> <Plug>(vsnip-cut-text) :set operatorfunc=<SID>vsnip_cut_text_normal<CR>g@
+snoremap <silent> <Plug>(vsnip-cut-text) <C-g>:<C-u>call <SID>vsnip_visual_text(visualmode())<CR>gv"_c
+xnoremap <silent> <Plug>(vsnip-cut-text) :<C-u>call <SID>vsnip_visual_text(visualmode())<CR>gv"_c
+
+function! s:vsnip_cut_text_normal(type) abort
+  call s:vsnip_set_text(a:type, 'd')
+  call feedkeys('a', 'n')
+endfunction
+function! s:vsnip_visual_text(type) abort
+  call s:vsnip_set_text(a:type, 'y')
+endfunction
+function! s:vsnip_set_text(type, copy) abort
   let reg_v = @v
   if a:type ==# 'v'
-    normal! `<v`>"vy
+    let select = '`<v`>"v'
   elseif a:type ==# 'V'
-    normal! '<V'>"vy
+    let select = "'<V'>\"v"
   elseif a:type ==? ''
-    normal! `<`>"vy
+    let select = '`<`>"v'
   elseif a:type ==# 'char'
-    normal! `[v`]"vy
+    let select = '`[v`]"v'
   elseif a:type ==# 'line'
-    normal! '[V']"vy
+    let select = "'[V']\"v"
   else
     return
   endif
+  execute 'normal! '.select.a:copy
   call vsnip#selected_text(substitute(@v, '\n$', '', ''))
   let @v = reg_v
 endfunction

--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -104,9 +104,11 @@ function! s:get_visual_text(type) abort
   if a:type ==# 'v'
     normal! `<v`>"vy
   elseif a:type ==# 'V'
-    normal! '[V']"vy
+    normal! '<V'>"vy
   elseif a:type ==# 'char'
     normal! `[v`]"vy
+  elseif a:type ==# 'line'
+    normal! '[V']"vy
   else
     return
   endif

--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -125,7 +125,8 @@ xnoremap <silent> <Plug>(vsnip-cut-text) :<C-u>call <SID>vsnip_visual_text(visua
 
 function! s:vsnip_cut_text_normal(type) abort
   call s:vsnip_set_text(a:type, 'd')
-  call feedkeys('a', 'n')
+  let insertmode = s:virtualedit_in_normal() ? 'i' : 'a'
+  call feedkeys(insertmode, 'n')
 endfunction
 function! s:vsnip_visual_text(type) abort
   call s:vsnip_set_text(a:type, 'y')
@@ -139,6 +140,7 @@ function! s:vsnip_set_text(type, copy) abort
   elseif a:type ==? ''
     let select = '`<`>"v'
   elseif a:type ==# 'char'
+        \ || (a:type ==# 'line' && s:virtualedit_in_normal())
     let select = '`[v`]"v'
   elseif a:type ==# 'line'
     let select = "'[V']\"v"
@@ -148,6 +150,9 @@ function! s:vsnip_set_text(type, copy) abort
   execute 'normal! '.select.a:copy
   call vsnip#selected_text(substitute(@v, '\n$', '', ''))
   let @v = reg_v
+endfunction
+function! s:virtualedit_in_normal() abort
+  return &virtualedit =~? '\<all\>'
 endfunction
 
 "

--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -94,15 +94,19 @@ function! s:jump(direction) abort
 endfunction
 
 "
-" <Plug>(vsnip-set-selected-text)
+" <Plug>(vsnip-select-text)
 "
-xnoremap <silent> <Plug>(vsnip-set-selected-text) :<C-u>call <SID>get_visual_text(visualmode())<CR>gvs
+nnoremap <silent> <Plug>(vsnip-select-text) :set operatorfunc=<SID>get_visual_text<CR>g@
+snoremap <silent> <Plug>(vsnip-select-text) <C-g>:<C-u>call <SID>get_visual_text(visualmode())<CR>gv<C-g>
+xnoremap <silent> <Plug>(vsnip-select-text) :<C-u>call <SID>get_visual_text(visualmode())<CR>gv
 function! s:get_visual_text(type) abort
   let reg_v = @v
   if a:type ==# 'v'
     normal! `<v`>"vy
   elseif a:type ==# 'V'
     normal! '[V']"vy
+  elseif a:type ==# 'char'
+    normal! `[v`]"vy
   else
     return
   endif

--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -105,6 +105,8 @@ function! s:get_visual_text(type) abort
     normal! `<v`>"vy
   elseif a:type ==# 'V'
     normal! '<V'>"vy
+  elseif a:type ==? ''
+    normal! `<`>"vy
   elseif a:type ==# 'char'
     normal! `[v`]"vy
   elseif a:type ==# 'line'

--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -94,6 +94,23 @@ function! s:jump(direction) abort
 endfunction
 
 "
+" <Plug>(vsnip-set-selected-text)
+"
+xnoremap <silent> <Plug>(vsnip-set-selected-text) :<C-u>call <SID>get_visual_text(visualmode())<CR>gvs
+function! s:get_visual_text(type) abort
+  let reg_v = @v
+  if a:type ==# 'v'
+    normal! `<v`>"vy
+  elseif a:type ==# 'V'
+    normal! '[V']"vy
+  else
+    return
+  endif
+  call vsnip#selected_text(@v)
+  let @v = reg_v
+endfunction
+
+"
 " map
 "
 function! s:map(fn) abort

--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -64,6 +64,7 @@ endfunction
 " <Plug>(vsnip-expand)
 "
 inoremap <silent> <Plug>(vsnip-expand) <Esc>:<C-u>call <SID>expand()<CR>
+snoremap <silent> <Plug>(vsnip-expand) <C-g>o<Esc>:<C-u>call <SID>expand()<CR>
 function! s:expand() abort
   let l:ctx = {}
   function! l:ctx.callback() abort


### PR DESCRIPTION
This PR allows to add a mapping which will store the current visual selection as `$TM_SELECTED_TEXT` in the next expanded snippet.

This Closes #49 `a)`

Example:
```json
{
  "snippet": {
    "prefix": ["au"],
    "body": [ "autocmd $TM_SELECTED_TEXT" ],
    "description": "Example for selected text"
  }
}
```
```vim
xmap        <C-l>  <Plug>(vsnip-set-selected-text)
imap <expr> <C-l>  vsnip#available(1)  ? '<Plug>(vsnip-expand-or-jump)' : '<C-l>'
```

- Now you can select some text in visual mode.
- Press `<C-l>`. This will store the text in vsnip, remove the text and
  place you in insert mode.
- Now type `au` and press `<C-l>` again.

The result will be `autocmd your visual selected text here`.

Caveat: `Ctrl-v` (Visual Block) is not yet supported. I'm not sure how
the text should be concatenated.