### PR TITLE
Support expanding snippets from select mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ NeoBundle 'hrsh7th/vim-vsnip-integ'
 ```viml
 " You can use other key to expand snippet.
 imap <expr> <C-j>   vsnip#available(1)  ? '<Plug>(vsnip-expand)'         : '<C-j>'
-" Expand selected placeholder with <C-j>
+" Expand selected placeholder with <C-j> (see https://github.com/hrsh7th/vim-vsnip/pull/51)
 smap <expr> <C-j>   vsnip#expandable()  ? '<Plug>(vsnip-expand)'         : '<C-j>'
 imap <expr> <C-l>   vsnip#available(1)  ? '<Plug>(vsnip-expand-or-jump)' : '<C-l>'
 " Jump to the next placeholder with <C-l>

--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ NeoBundle 'hrsh7th/vim-vsnip-integ'
 ```viml
 " You can use other key to expand snippet.
 imap <expr> <C-j>   vsnip#available(1)  ? '<Plug>(vsnip-expand)'         : '<C-j>'
+" Expand selected placeholder with <C-j>
+smap <expr> <C-j>   vsnip#expandable()  ? '<Plug>(vsnip-expand)'         : '<C-j>'
 imap <expr> <C-l>   vsnip#available(1)  ? '<Plug>(vsnip-expand-or-jump)' : '<C-l>'
+" Jump to the next placeholder with <C-l>
 smap <expr> <C-l>   vsnip#available(1)  ? '<Plug>(vsnip-expand-or-jump)' : '<C-l>'
 imap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
 smap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'

--- a/autoload/vsnip.vim
+++ b/autoload/vsnip.vim
@@ -21,9 +21,16 @@ endfunction
 "
 function! vsnip#available(...) abort
   let l:direction = get(a:000, 0, 1)
-  let l:expandable = !empty(vsnip#get_context())
+  let l:expandable = vsnip#expandable()
   let l:jumpable = !empty(s:session) && s:session.jumpable(l:direction)
   return l:expandable || l:jumpable
+endfunction
+
+"
+" vsnip#expandable.
+"
+function! vsnip#expandable() abort
+  return !empty(vsnip#get_context())
 endfunction
 
 "

--- a/doc/vsnip.txt
+++ b/doc/vsnip.txt
@@ -104,6 +104,7 @@ The below example uses '<Tab>' key.
 
 >
   imap <expr> <C-j>   vsnip#available(1)  ? '<Plug>(vsnip-expand)'         : '<C-j>'
+  smap <expr> <C-j>   vsnip#expandable(1) ? '<Plug>(vsnip-expand)'         : '<C-j>'
   imap <expr> <C-l>   vsnip#available(1)  ? '<Plug>(vsnip-expand-or-jump)' : '<C-l>'
   imap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
   smap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'

--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -64,6 +64,7 @@ endfunction
 " <Plug>(vsnip-expand)
 "
 inoremap <silent> <Plug>(vsnip-expand) <Esc>:<C-u>call <SID>expand()<CR>
+snoremap <silent> <Plug>(vsnip-expand) <C-g>o<Esc>:<C-u>call <SID>expand()<CR>
 function! s:expand() abort
   let l:ctx = {}
   function! l:ctx.callback() abort


### PR DESCRIPTION
This PR allows to add a mapping in select mode which will expand a snippet if one exists.

This Closes #49 `b)`

Example:
```json
{
  "Augroup": {
    "prefix": ["aug"],
    "body": [
      "augroup my_augroup",
      "\tau!",
      "\t${1:auc}",
      "augroup END"
    ],
    "description": "Augroup wrapper."
  },
  "Autocmd": {
    "prefix": ["auc"],
    "body": [ "autocmd ${1:autocmd ${2:VimEnter} ${3:*}} $0" ],
    "description": "Function definition template."
  }
}
```
```vim
imap <expr> <C-j>   vsnip#available(1)  ? '<Plug>(vsnip-expand)'         : '<C-j>'
" Expand selected placeholder with <C-j>
smap <expr> <C-j>   vsnip#expandable()  ? '<Plug>(vsnip-expand)'         : '<C-j>'
```

Type `aug` and then press `<C-j>`. This will expand the `aug` snippet and jump to the first tabstop with `auc` in select mode.
Now press `<C-j>` again to expand the `auc` snippet.