### PR TITLE
BUG: join placeholders when to use nested snippets

### DIFF
--- a/autoload/vsnip/session/snippet.vim
+++ b/autoload/vsnip/session/snippet.vim
@@ -352,6 +352,8 @@ function! s:Snippet.normalize() abort
       endif
     endif
 
+    let self.placeholder = v:null
+    let self.text = v:null
     let self[a:node.type] = {
     \   'range': a:range,
     \   'node': a:node,

--- a/autoload/vsnip/session/snippet.vim
+++ b/autoload/vsnip/session/snippet.vim
@@ -331,30 +331,20 @@ endfunction
 "
 function! s:Snippet.normalize() abort
   let l:fn = {}
-  let l:fn.placeholder = v:null
   let l:fn.text = v:null
   function! l:fn.traverse(range, node, parent, depth) abort
-    " Check placeholder.
-    if !empty(self.placeholder) && self.placeholder.depth == a:depth
-      if self.placeholder.node.type ==# 'placeholder' && a:node.type ==# 'placeholder'
-        if self.placeholder.range[0] == a:range[0] && self.placeholder.range[1] == a:range[1]
-          call remove(self.placeholder.parent.children, index(self.placeholder.parent.children, self.placeholder.node))
-        endif
-      endif
+    if a:node.type !=# 'text'
+      let self.text = v:null
+      return
     endif
 
-    " Check text.
     if !empty(self.text) && self.text.depth == a:depth
-      if self.text.node.type ==# 'text' && a:node.type ==# 'text'
-        let self.text.node.value .= a:node.value
-        call remove(a:parent.children, index(a:parent.children, a:node))
-        return
-      endif
+      let self.text.node.value .= a:node.value
+      call remove(a:parent.children, index(a:parent.children, a:node))
+      return
     endif
 
-    let self.placeholder = v:null
-    let self.text = v:null
-    let self[a:node.type] = {
+    let self.text = {
     \   'range': a:range,
     \   'node': a:node,
     \   'parent': a:parent,

--- a/autoload/vsnip/session/snippet.vimspec
+++ b/autoload/vsnip/session/snippet.vimspec
@@ -239,6 +239,17 @@ Describe vsnip#snippet
       call s:expect(l:text).to_equal(l:snippet.text())
     End
 
+    It Should normalize 3
+      let l:snippet = s:Snippet.new(s:start_position, '${1:i}${2:++}')
+      let l:text = l:snippet.text()
+      call s:expect(len(l:snippet.children)).to_equal(3)
+      call l:snippet.normalize()
+      call s:expect(len(l:snippet.children)).to_equal(3)
+      call s:expect(l:snippet.children[0].children[0]['value']).to_equal('i')
+      call s:expect(l:snippet.children[1].children[0]['value']).to_equal('++')
+      call s:expect(l:text).to_equal(l:snippet.text())
+    End
+
   End
 
   Describe #insert_node

--- a/autoload/vsnip/session/snippet.vimspec
+++ b/autoload/vsnip/session/snippet.vimspec
@@ -225,7 +225,7 @@ Describe vsnip#snippet
       let l:text = l:snippet.text()
       call s:expect(len(l:snippet.children)).to_equal(5)
       call l:snippet.normalize()
-      call s:expect(len(l:snippet.children)).to_equal(4)
+      call s:expect(len(l:snippet.children)).to_equal(5)
       call s:expect(l:text).to_equal(l:snippet.text())
     End
 

--- a/autoload/vsnip/session/snippet.vimspec
+++ b/autoload/vsnip/session/snippet.vimspec
@@ -241,13 +241,9 @@ Describe vsnip#snippet
 
     It Should normalize 3
       let l:snippet = s:Snippet.new(s:start_position, '${1:i}${2:++}')
-      let l:text = l:snippet.text()
-      call s:expect(len(l:snippet.children)).to_equal(3)
-      call l:snippet.normalize()
-      call s:expect(len(l:snippet.children)).to_equal(3)
-      call s:expect(l:snippet.children[0].children[0]['value']).to_equal('i')
-      call s:expect(l:snippet.children[1].children[0]['value']).to_equal('++')
-      call s:expect(l:text).to_equal(l:snippet.text())
+      let l:children = deepcopy(l:snippet.children)
+      call l:snippet.normalize()  " Don't change anything
+      call s:expect(l:snippet.children).to_equal(l:children)
     End
 
   End


### PR DESCRIPTION
Hi @hrsh7th . Thanks for the nice plugin.

I used the following snippet nested together. But `++` was deleted as the image shows.
I found that `s:Snippet.normalize` join `$1${3:++}` to `$1`.

```json
{
  "for statement": {
    "prefix": "for",
    "body": "for ${1:index} := 0; $1 < ${2:count}; $1${3:++} {\n\t$0\n}",
    "description": "Snippet for a for loop"                                                                                                                   
  }
}
```

![kitad_ tmux a 2020_07_16 23_24_42](https://user-images.githubusercontent.com/21323222/87683080-96246200-c7bb-11ea-93c4-876c5050ab66.png)
