### PR TITLE
Improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 VSCode(LSP)'s snippet feature in vim.
 
-vsnip can integrate some other plugins via [vim-vsnip-integ](https://github.com/hrsh7th/vim-vsnip-integ). (e.g. [vim-lsp](https://github.com/prabirshrestha/vim-lsp))
-
 
 # DEMO
 
@@ -13,21 +11,31 @@ vsnip can integrate some other plugins via [vim-vsnip-integ](https://github.com/
 # Concept
 
 - Standard features written in Pure Vim script.
-- Support VSCode(LSP)'s snippet format.
-- Some LSP client integration.
+- Implement LSP snippet format
+- Support LSP-client and completion-engine by [vim-vsnip-integ](https://github.com/hrsh7th/vim-vsnip-integ)
+  - LSP-client
+    - [vim-lsp](https://github.com/prabirshrestha/vim-lsp)
+    - [vim-lsc](https://github.com/natebosch/vim-lsc)
+    - [LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim)
+    - [neovim built-in lsp](https://github.com/neovim/neovim)
+    - [vim-lamp](https://github.com/hrsh7th/vim-lamp)
+  - completion-engine
+    - [deoplete.nvim](https://github.com/Shougo/deoplete.nvim)
+    - [asyncomplete.vim](https://github.com/prabirshrestha/asyncomplete.vim)
+    - [vim-mucomplete](https://github.com/lifepillar/vim-mucomplete)
+    - [completion-nvim](https://github.com/haorenW1025/completion-nvim)
 
 
 # Features
 
-- VSCode's snippet format support.
+- Nested placeholders
+  - You can define snippet like `console.log($1${2:, $1})$0`
 - Nested snippet expansion
-    - You can expand snippet even if you already activated other snippet.
-    - Those snippet are merged one snippeet and works fine.
-- Load snippet from VSCode's extension.
-    - You can load snippet via `Plug 'microsoft/vscode-python'` etc.
-    - If you use `dein.nvim`, You should set `merged` flag to 0.
-- Some LSP client integration.
-    - You can find how to integrate those plugins in [here](https://github.com/hrsh7th/vim-vsnip-integ).
+    - You can expand snippet even if you already activated other snippet (it will be merged as one snippet)
+- Load snippet from VSCode extension
+    - If you install VSCode extension via `Plug 'microsoft/vscode-python'`, vsnip will load those snippets.
+- Support many LSP-client & completion-engine
+    - You can get how to integrate those plugins in [here](https://github.com/hrsh7th/vim-vsnip-integ).
 
 
 # Usage
@@ -47,36 +55,39 @@ NeoBundle 'hrsh7th/vim-vsnip'
 NeoBundle 'hrsh7th/vim-vsnip-integ'
 ```
 
+
 ### 2. Setting
 
 ```viml
-" You can use other key to expand snippet.
+" NOTE: You can use other key to expand snippet.
+
+" Expand
 imap <expr> <C-j>   vsnip#available(1)  ? '<Plug>(vsnip-expand)'         : '<C-j>'
-" Expand selected placeholder with <C-j> (see https://github.com/hrsh7th/vim-vsnip/pull/51)
 smap <expr> <C-j>   vsnip#expandable()  ? '<Plug>(vsnip-expand)'         : '<C-j>'
+
+" Expand or jump
 imap <expr> <C-l>   vsnip#available(1)  ? '<Plug>(vsnip-expand-or-jump)' : '<C-l>'
-" Jump to the next placeholder with <C-l>
 smap <expr> <C-l>   vsnip#available(1)  ? '<Plug>(vsnip-expand-or-jump)' : '<C-l>'
+
+" Jump forward or backward
 imap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
 smap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
 imap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
 smap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
-" Select text to use as $TM_SELECTED_TEXT in the next snippet.
-" See https://github.com/hrsh7th/vim-vsnip/pull/50
-" These mappings will behave like normal `c`. They select the text, remove it
-" and place you in insert mode.
-nmap        <C-j>   <Plug>(vsnip-cut-text)
-xmap        <C-j>   <Plug>(vsnip-cut-text)
-smap        <C-j>   <Plug>(vsnip-cut-text)
-" This will select the text and your in the exact same mode as before.
+
+" Select or cut text to use as $TM_SELECTED_TEXT in the next snippet. see https://github.com/hrsh7th/vim-vsnip/pull/50
 nmap        <C-l>   <Plug>(vsnip-select-text)
 xmap        <C-l>   <Plug>(vsnip-select-text)
 smap        <C-l>   <Plug>(vsnip-select-text)
+nmap        <C-j>   <Plug>(vsnip-cut-text)
+xmap        <C-j>   <Plug>(vsnip-cut-text)
+smap        <C-j>   <Plug>(vsnip-cut-text)
 ```
+
 
 ### 3. Create your own snippet
 
-Snippet source file will store to `g:vsnip_snippet_dir` per filetype.
+Snippet file will store to `g:vsnip_snippet_dir` per filetype.
 
 1. Open some file (example: `Sample.js`)
 2. Invoke `:VsnipOpen` command.
@@ -101,33 +112,17 @@ Snippet source file will store to `g:vsnip_snippet_dir` per filetype.
 The snippet format was described in [here](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax) or [here](https://github.com/Microsoft/language-server-protocol/blob/master/snippetSyntax.md).
 
 
-# Documentation
+# Development
 
-See `./doc/vsnip.txt`
+### How to run test it?
 
-
-# Integration
-
-- You can use [vim-vsnip-integ](https://github.com/hrsh7th/vim-vsnip-integ)
+You can run `npm run test` after install [vim-themis](https://github.com/thinca/vim-themis).
 
 
-# Why create vim-vsnip?
+### How sync same tabstop placeholders?
 
-- I want to support VSCode(LSP)'s snippet format.
-    - Some LSP client plugins has no snippet feature.
-    - This plugin aims to integrate those plugins.
-- I want to snippet plugin that written in Pure Vim script.
-    - For example, `vim-lsp`, `vim-lsc` are written in Pure Vim script.
-    - If snippet plugin needs `python`, `lua` etc, will breaks those plugins advantage.
-- I want to study parser combinator.
+1. compute the `user-diff` ... `s:Session.flush_changes`
+2. reflect the `user-diff` to snippet ast ... `s:Snippet.follow`
+3. reflect the `sync-diff` to buffer content ... `s:Snippet.sync & s:Session.flush_changes`
 
-
-# TODO
-
-- Should convert filetype to LSP's languageId.
-    - It's breaking change...
-- Support more features in VSCode(LSP) spec.
-    - regex transform
-- Some other useful features.
-    - feel free to send request.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ smap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab
 imap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
 smap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
 
-" Select or cut text to use as $TM_SELECTED_TEXT in the next snippet. see https://github.com/hrsh7th/vim-vsnip/pull/50
+" Select or cut text to use as $TM_SELECTED_TEXT in the next snippet.
+" See https://github.com/hrsh7th/vim-vsnip/pull/50
 nmap        <C-l>   <Plug>(vsnip-select-text)
 xmap        <C-l>   <Plug>(vsnip-select-text)
 smap        <C-l>   <Plug>(vsnip-select-text)

--- a/autoload/vsnip.vim
+++ b/autoload/vsnip.vim
@@ -63,17 +63,15 @@ function! vsnip#anonymous(text) abort
   let l:session = s:Session.new(bufnr('%'), s:Position.cursor(), a:text)
   call vsnip#selected_text('')
 
+  if !empty(s:session)
+    call s:session.flush_changes() " try to sync buffer content because vsnip#expand maybe remove prefix
+  endif
+
   if empty(s:session)
     let s:session = l:session
     call s:session.insert()
   else
-    call s:session.on_text_changed()
-    if !empty(s:session)
-      call s:session.merge(l:session)
-    else
-      let s:session = l:session
-      call s:session.insert()
-    endif
+    call s:session.merge(l:session)
   endif
 
   call s:session.refresh()

--- a/autoload/vsnip/session.vim
+++ b/autoload/vsnip/session.vim
@@ -234,7 +234,10 @@ function! s:Session.flush_changes() abort
   " if follow succeeded, sync placeholders and write back to the buffer.
   if self.snippet.follow(self.tabstop, l:diff)
     try
-      undojoin | call s:TextEdit.apply(self.bufnr, self.snippet.sync())
+      let l:text_edits = self.snippet.sync()
+      if len(l:text_edits) > 0
+        undojoin | call s:TextEdit.apply(self.bufnr, l:text_edits)
+      endif
       call self.refresh()
     catch /.*/
       " TODO: More strict changenrs mangement.

--- a/autoload/vsnip/session.vim
+++ b/autoload/vsnip/session.vim
@@ -17,14 +17,15 @@ let s:Session = {}
 "
 function! s:Session.new(bufnr, position, text) abort
   return extend(deepcopy(s:Session), {
-        \   'bufnr': a:bufnr,
-        \   'buffer': getbufline(a:bufnr, '^', '$'),
-        \   'timer_id': -1,
-        \   'snippet': s:Snippet.new(a:position, self.indent(a:text)),
-        \   'tabstop': -1,
-        \   'changenr': changenr(),
-        \   'changenrs': {},
-        \ })
+  \   'bufnr': a:bufnr,
+  \   'buffer': getbufline(a:bufnr, '^', '$'),
+  \   'timer_id': -1,
+  \   'changedtick': getbufvar(a:bufnr, 'changedtick', 0),
+  \   'snippet': s:Snippet.new(a:position, self.indent(a:text)),
+  \   'tabstop': -1,
+  \   'changenr': changenr(),
+  \   'changenrs': {},
+  \ })
 endfunction
 
 "
@@ -33,12 +34,12 @@ endfunction
 function! s:Session.insert() abort
   " insert snippet.
   call s:TextEdit.apply(self.bufnr, [{
-        \   'range': {
-        \     'start': self.snippet.position,
-        \     'end': self.snippet.position
-        \   },
-        \   'newText': self.snippet.text()
-        \ }])
+  \   'range': {
+  \     'start': self.snippet.position,
+  \     'end': self.snippet.position
+  \   },
+  \   'newText': self.snippet.text()
+  \ }])
   call self.store(changenr())
 endfunction
 
@@ -48,7 +49,7 @@ endfunction
 function! s:Session.merge(session) abort
   call a:session.insert()
 
-  " Fix tabstop1
+  " increase new snippet's tabstop by current snippet's current tabstop
   let l:offset = 1
   let l:tabstop_map = {}
   for l:node in a:session.snippet.get_placeholder_nodes()
@@ -60,7 +61,7 @@ function! s:Session.merge(session) abort
   endfor
   let l:tail = l:node
 
-  " Fix tabstop2
+  " re-assign current snippet's tabstop by new snippet's final tabstop
   let l:offset = 1
   let l:tabstop_map = {}
   for l:node in self.snippet.get_placeholder_nodes()
@@ -94,6 +95,8 @@ endfunction
 " jump.
 "
 function! s:Session.jump(direction) abort
+  call self.flush_changes()
+
   if a:direction == 1
     let l:jump_point = self.snippet.get_next_jump_point(self.tabstop)
   else
@@ -133,11 +136,11 @@ function! s:Session.choice(jump_point) abort
     if mode()[0] ==# 'i'
       let l:pos = s:Position.lsp_to_vim('%', self.jump_point.range.start)
       call complete(l:pos[1], map(copy(self.jump_point.placeholder.choice), { k, v -> {
-            \   'word': v.escaped,
-            \   'abbr': v.escaped,
-            \   'menu': '[vsnip]',
-            \   'kind': 'Choice'
-            \ } }))
+      \   'word': v.escaped,
+      \   'abbr': v.escaped,
+      \   'menu': '[vsnip]',
+      \   'kind': 'Choice'
+      \ } }))
     endif
   endfunction
   call timer_start(g:vsnip_choice_delay, { -> l:fn.next_tick() })
@@ -201,56 +204,48 @@ function! s:Session.on_text_changed() abort
     endif
   endif
 
-  let l:fn = {}
-  function! l:fn.debounce(timer_id) abort
-    " compute diff.
-    let l:buffer = getbufline(self.bufnr, '^', '$')
-    let l:diff = s:Diff.compute(self.buffer, l:buffer)
-    let self.buffer = l:buffer
-    if l:diff.rangeLength == 0 && l:diff.text ==# ''
-      return
-    endif
-
-    " text edit is out of range.
-    let l:range = self.snippet.range()
-    if l:diff.range.start.line < l:range.start.line
-      return vsnip#deactivate()
-    endif
-    if l:range.end.line < l:diff.range.end.line
-      return vsnip#deactivate()
-    endif
-    if l:diff.range.start.line == l:range.start.line && l:diff.range.start.character < l:range.start.character
-      return vsnip#deactivate()
-    endif
-    if l:diff.range.end.line == l:range.end.line && l:range.end.character < l:diff.range.end.character
-      return vsnip#deactivate()
-    endif
-
-    " snippet text is not changed.
-    if !self.is_dirty(l:buffer, l:diff)
-      return
-    endif
-
-    " if follow succeeded, sync placeholders and write back to the buffer.
-    if self.snippet.follow(self.tabstop, l:diff)
-      try
-        undojoin | call s:TextEdit.apply(self.bufnr, self.snippet.sync())
-        call self.refresh()
-      catch /.*/
-        " TODO: More strict changenrs mangement.
-        call vsnip#deactivate()
-      endtry
-    else
-      call vsnip#deactivate()
-    endif
-  endfunction
-
-  " if delay is not zero, should debounce.
   if g:vsnip_sync_delay == 0
-    call call(l:fn.debounce, [0], self)
+    call self.flush_changes()
   else
     call timer_stop(self.timer_id)
-    let self.timer_id = timer_start(g:vsnip_sync_delay, function(l:fn.debounce, [], self), { 'repeat': 1 })
+    let self.timer_id = timer_start(g:vsnip_sync_delay, { -> self.flush_changes() }, { 'repeat': 1 })
+  endif
+endfunction
+
+"
+" flush_changes
+"
+function! s:Session.flush_changes() abort
+  let l:changedtick = getbufvar(self.bufnr, 'changedtick', 0)
+  if self.changedtick == l:changedtick
+    return
+  endif
+  let self.changedtick = l:changedtick
+
+  " compute diff.
+  let l:buffer = getbufline(self.bufnr, '^', '$')
+  let l:diff = s:Diff.compute(self.buffer, l:buffer)
+  let self.buffer = l:buffer
+  if l:diff.rangeLength == 0 && l:diff.text ==# ''
+    return
+  endif
+
+  " snippet text is not changed.
+  if !self.is_dirty(l:buffer, l:diff)
+    return
+  endif
+
+  " if follow succeeded, sync placeholders and write back to the buffer.
+  if self.snippet.follow(self.tabstop, l:diff)
+    try
+      undojoin | call s:TextEdit.apply(self.bufnr, self.snippet.sync())
+      call self.refresh()
+    catch /.*/
+      " TODO: More strict changenrs mangement.
+      call vsnip#deactivate()
+    endtry
+  else
+    call vsnip#deactivate()
   endif
 endfunction
 
@@ -259,9 +254,9 @@ endfunction
 "
 function! s:Session.store(changenr) abort
   let self.changenrs[a:changenr] = {
-        \   'tabstop': self.tabstop,
-        \   'snippet': deepcopy(self.snippet)
-        \ }
+  \   'tabstop': self.tabstop,
+  \   'snippet': deepcopy(self.snippet)
+  \ }
 endfunction
 
 "
@@ -292,15 +287,15 @@ function! s:Session.text_from_buffer(buffer, diff) abort
       let l:text = strcharpart(a:buffer[l:i], l:range.start.character, l:range.end.character - l:range.start.character)
       break
 
-    " multi start.
+      " multi start.
     elseif l:i == l:range.start.line
       let l:text .= strcharpart(a:buffer[l:i], l:range.start.character, strchars(a:buffer[l:i]) - l:range.start.character) . "\n"
 
-    " multi middle.
+      " multi middle.
     elseif l:i != l:range.end.line
       let l:text .= a:buffer[l:i] . "\n"
 
-    " multi end.
+      " multi end.
     elseif l:i == l:range.end.line
       let l:text .= strcharpart(a:buffer[l:i], 0, l:range.end.character)
     endif

--- a/autoload/vsnip/session/snippet.vim
+++ b/autoload/vsnip/session/snippet.vim
@@ -165,13 +165,6 @@ endfunction
 "
 " sync.
 "
-" # placeholders.
-" LSP spec says, multiple placeholders can has same tabstops.
-" If the placeholders has multiple candidate of default text, use `first occurrence`.
-"
-" # variables.
-" Variable should transform to text node.
-"
 function! s:Snippet.sync() abort
   let l:fn = {}
   let l:fn.new_texts = {}

--- a/autoload/vsnip/session/snippet.vim
+++ b/autoload/vsnip/session/snippet.vim
@@ -125,11 +125,10 @@ function! s:Snippet.follow(current_tabstop, diff) abort
   endfunction
   call self.traverse(self, self.children, l:fn.traverse, 0, 0)
 
-  if empty(l:fn.target)
+  let l:target = l:fn.target
+  if empty(l:target)
     return v:false
   endif
-
-  let l:target = l:fn.target
 
   " Create patched new text.
   let l:start = a:diff.range[0] - l:target.range[0] - 1

--- a/autoload/vsnip/session/snippet.vimspec
+++ b/autoload/vsnip/session/snippet.vimspec
@@ -2,165 +2,175 @@ let s:expect = themis#helper('expect')
 let s:Snippet = vsnip#session#snippet#import()
 
 let s:start_position = {
-      \   'line': 1,
-      \   'character': 1
-      \ }
+\   'line': 1,
+\   'character': 1
+\ }
 
 Describe vsnip#snippet
 
-  Describe #follow
+  Describe #init
 
-    It Should follow diff overlap left
-      let l:snippet = s:Snippet.new(s:start_position, "class $1 {\n\tpublic ${2:default}() {\n\t\t$0\n\t}\n}")
-      let l:followed = l:snippet.follow(0, {
-            \   'range': {
-            \     'start': {
-            \       'line': 2,
-            \       'character': 1
-            \     },
-            \     'end': {
-            \       'line': 2,
-            \       'character': 12
-            \     }
-            \   },
-            \   'text': '___'
-            \ })
-      call s:expect(l:followed).to_equal(v:false)
+    It should mark follower placeholders
+      let l:snippet = s:Snippet.new(s:start_position, 'console.log(${1:default}, $1, $1)')
+      call s:expect(l:snippet.children[3].follower).to_equal(v:true)
+      call s:expect(l:snippet.children[5].follower).to_equal(v:true)
     End
 
-    It Should follow diff overlap right
-      let l:snippet = s:Snippet.new(s:start_position, "class $1 {\n\tpublic ${2:default}() {\n\t\t$0\n\t}\n}")
-      let l:followed = l:snippet.follow(0, {
-            \   'range': {
-            \     'start': {
-            \       'line': 2,
-            \       'character': 12
-            \     },
-            \     'end': {
-            \       'line': 2,
-            \       'character': 17
-            \     }
-            \   },
-            \   'text': '___(params)'
-            \ })
-      call s:expect(l:followed).to_equal(v:false)
+    It should add final tabstop
+      let l:snippet = s:Snippet.new(s:start_position, 'console.log($1)')
+      call s:expect(l:snippet.children[3].is_final).to_equal(v:true)
     End
 
-    It Should follow diff cover
-      let l:snippet = s:Snippet.new(s:start_position, "class $1 {\n\tpublic ${2:default}() {\n\t\t$0\n\t}\n}")
-      let l:followed = l:snippet.follow(0, {
-            \   'range': {
-            \     'start': {
-            \       'line': 2,
-            \       'character': 7
-            \     },
-            \     'end': {
-            \       'line': 2,
-            \       'character': 16
-            \     }
-            \   },
-            \   'text': '___'
-            \ })
-      call s:expect(l:followed).to_equal(v:false)
-    End
-
-    It Should follow diff include
-      let l:snippet = s:Snippet.new(s:start_position, "class $1 {\n\tpublic ${2:default}() {\n\t\t$0\n\t}\n}")
-      call l:snippet.follow(0, {
-            \   'range': {
-            \     'start': {
-            \       'line': 2,
-            \       'character': 9
-            \     },
-            \     'end': {
-            \       'line': 2,
-            \       'character': 12
-            \     }
-            \   },
-            \   'text': '___'
-            \ })
-      call s:expect(l:snippet.text()).to_equal("class  {\n\tpublic d___ult() {\n\t\t\n\t}\n}")
-      call s:expect(l:snippet.get_next_jump_point(1).placeholder.text()).to_equal('d___ult')
-    End
-
-  End
-
-  Describe #sync
-
-    It Should sync same tabstop placeholder 1
-      let l:snippet = s:Snippet.new(s:start_position, 'console.log(${1:default}, $1)')
-      call s:expect(l:snippet.text()).to_equal('console.log(default, default)')
-    End
-
-    It Should sync same tabstop placeholder 2
-      let l:snippet = s:Snippet.new(s:start_position, 'console.log(${1:default}, $1)')
-      call l:snippet.follow(0, {
-            \   'range': {
-            \     'start': {
-            \       'line': 1,
-            \       'character': 13
-            \     },
-            \     'end': {
-            \       'line': 1,
-            \       'character': 17
-            \     }
-            \   },
-            \   'text': '___'
-            \ })
-      call l:snippet.sync()
-      call s:expect(l:snippet.text()).to_equal('console.log(___ult, ___ult)')
-    End
-
-    It Should sync variable placeholder 1
+    It should convert variable to placeholder
       let l:snippet = s:Snippet.new(s:start_position, 'console.log(${variable:default}, $variable)')
       call s:expect(l:snippet.text()).to_equal('console.log(default, default)')
+      call s:expect(l:snippet.children[3].follower).to_equal(v:true)
     End
 
-    It Should sync variable placeholder 2
-      let l:snippet = s:Snippet.new(s:start_position, 'console.log(${variable:default}, $variable)')
-      call l:snippet.follow(0, {
-            \   'range': {
-            \     'start': {
-            \       'line': 1,
-            \       'character': 13
-            \     },
-            \     'end': {
-            \       'line': 1,
-            \       'character': 17
-            \     }
-            \   },
-            \   'text': '___'
-            \ })
-      call l:snippet.sync()
-      call s:expect(l:snippet.text()).to_equal('console.log(___ult, ___ult)')
-    End
-
-    It Should sync known variable
+    It should resolve known variables
       let l:snippet = s:Snippet.new(s:start_position, 'console.log(${CURRENT_YEAR})')
       call s:expect(l:snippet.text()).to_equal('console.log(' . strftime('%Y') . ')')
     End
   End
 
+  Describe #sync
+
+    It should sync placeholder text in same tabstop groups
+      let l:snippet = s:Snippet.new(s:start_position, 'console.log(${1:default}, $1)')
+      call l:snippet.follow(0, {
+      \   'range': {
+      \     'start': {
+      \       'line': 1,
+      \       'character': 13
+      \     },
+      \     'end': {
+      \       'line': 1,
+      \       'character': 17
+      \     }
+      \   },
+      \   'text': '___'
+      \ })
+      call l:snippet.sync()
+      call s:expect(l:snippet.text()).to_equal('console.log(___ult, ___ult)')
+    End
+
+  End
+
+  Describe #follow
+
+    It should not follow when diff range includes nodes border(left)
+      let l:snippet = s:Snippet.new(s:start_position, "class $1 {\n\tpublic ${2:default}() {\n\t\t$0\n\t}\n}")
+      let l:followed = l:snippet.follow(0, {
+      \   'range': {
+      \     'start': {
+      \       'line': 2,
+      \       'character': 1
+      \     },
+      \     'end': {
+      \       'line': 2,
+      \       'character': 12
+      \     }
+      \   },
+      \   'text': '___'
+      \ })
+      call s:expect(l:followed).to_equal(v:false)
+    End
+
+    It should not follow when diff range includes nodes border(right)
+      let l:snippet = s:Snippet.new(s:start_position, "class $1 {\n\tpublic ${2:default}() {\n\t\t$0\n\t}\n}")
+      let l:followed = l:snippet.follow(0, {
+      \   'range': {
+      \     'start': {
+      \       'line': 2,
+      \       'character': 12
+      \     },
+      \     'end': {
+      \       'line': 2,
+      \       'character': 17
+      \     }
+      \   },
+      \   'text': '___(params)'
+      \ })
+      call s:expect(l:followed).to_equal(v:false)
+    End
+
+    It should not follow when diff range is overlap multiple nodes
+      let l:snippet = s:Snippet.new(s:start_position, "class $1 {\n\tpublic ${2:default}() {\n\t\t$0\n\t}\n}")
+      let l:followed = l:snippet.follow(0, {
+      \   'range': {
+      \     'start': {
+      \       'line': 2,
+      \       'character': 7
+      \     },
+      \     'end': {
+      \       'line': 2,
+      \       'character': 16
+      \     }
+      \   },
+      \   'text': '___'
+      \ })
+      call s:expect(l:followed).to_equal(v:false)
+    End
+
+    It should follow when diff range included by node range
+      let l:snippet = s:Snippet.new(s:start_position, "class $1 {\n\tpublic ${2:default}() {\n\t\t$0\n\t}\n}")
+      call l:snippet.follow(0, {
+      \   'range': {
+      \     'start': {
+      \       'line': 2,
+      \       'character': 9
+      \     },
+      \     'end': {
+      \       'line': 2,
+      \       'character': 12
+      \     }
+      \   },
+      \   'text': '___'
+      \ })
+      call s:expect(l:snippet.text()).to_equal("class  {\n\tpublic d___ult() {\n\t\t\n\t}\n}")
+      call s:expect(l:snippet.get_next_jump_point(1).placeholder.text()).to_equal('d___ult')
+    End
+
+    It should follow when diff range and snippet range are empty
+      let l:snippet = s:Snippet.new(s:start_position, '')
+      call l:snippet.follow(0, {
+      \   'range': {
+      \     'start': {
+      \       'line': 1,
+      \       'character': 1
+      \     },
+      \     'end': {
+      \       'line': 1,
+      \       'character': 1
+      \     }
+      \   },
+      \   'text': '___'
+      \ })
+      call s:expect(l:snippet.text()).to_equal('___')
+    End
+
+  End
+
   Describe #text
 
-    It Should return text1
+    It should return text1
       let l:snippet = s:Snippet.new(s:start_position, 'console.log($0${1:default})')
       call s:expect(l:snippet.text()).to_equal('console.log(default)')
     End
 
-    It Should return text2
+    It should return text2
       call vsnip#selected_text('THIS_IS_SELECTED_TEXT')
       let l:snippet = s:Snippet.new(s:start_position, '$TM_SELECTED_TEXT')
       call s:expect(l:snippet.text()).to_equal('THIS_IS_SELECTED_TEXT')
     End
 
-    It Should return text2
+    It should return text2
       call vsnip#selected_text('THIS_IS_SELECTED_TEXT')
       let l:snippet = s:Snippet.new(s:start_position, '${TM_SELECTED_TEXT}')
       call s:expect(l:snippet.text()).to_equal('THIS_IS_SELECTED_TEXT')
     End
 
-    It Should return text3
+    It should return text3
       call vsnip#selected_text('')
       let l:snippet = s:Snippet.new(s:start_position, '${TM_SELECTED_TEXT:default}')
       call s:expect(l:snippet.text()).to_equal('default')
@@ -170,63 +180,63 @@ Describe vsnip#snippet
 
   Describe #range
 
-    It Should return range1
+    It should return range1
       let l:snippet = s:Snippet.new(s:start_position, "01234\n56789")
       call s:expect(l:snippet.range()).to_equal({
-            \   'start': {
-            \     'line': s:start_position.line,
-            \     'character': s:start_position.character
-            \   },
-            \   'end': {
-            \     'line': s:start_position.line + 1,
-            \     'character': 5
-            \   }
-            \ })
+      \   'start': {
+      \     'line': s:start_position.line,
+      \     'character': s:start_position.character
+      \   },
+      \   'end': {
+      \     'line': s:start_position.line + 1,
+      \     'character': 5
+      \   }
+      \ })
     End
 
-    It Should return range2
+    It should return range2
       let l:snippet = s:Snippet.new(s:start_position, "012345")
       call s:expect(l:snippet.range()).to_equal({
-            \   'start': {
-            \     'line': s:start_position.line,
-            \     'character': s:start_position.character
-            \   },
-            \   'end': {
-            \     'line': s:start_position.line,
-            \     'character': 7
-            \   }
-            \ })
+      \   'start': {
+      \     'line': s:start_position.line,
+      \     'character': s:start_position.character
+      \   },
+      \   'end': {
+      \     'line': s:start_position.line,
+      \     'character': 7
+      \   }
+      \ })
     End
 
   End
 
   Describe #offset_to_position
 
-    It Should return position from offset
+    It should return position from offset
       let l:snippet = s:Snippet.new(s:start_position, "class クラス {\n\tpublic constructor() {\n\t\t$0\n\t}\n}")
       call s:expect(l:snippet.offset_to_position(13)).to_equal({
-            \   'line': 2,
-            \   'character': 1
-            \ })
+      \   'line': 2,
+      \   'character': 1
+      \ })
     End
 
   End
 
   Describe #position_to_offset
 
-    It Should return offset from position
+    It should return offset from position
       let l:snippet = s:Snippet.new(s:start_position, "class クラス {\n\tpublic constructor() {\n\t\t$0\n\t}\n}")
       call s:expect(l:snippet.position_to_offset({
-            \   'line': 2,
-            \   'character': 1
-            \ })).to_equal(13)
+      \   'line': 2,
+      \   'character': 1
+      \ })).to_equal(13)
     End
 
   End
 
   Describe #normalize
 
-    It Should normalize 1
+    It should normalize 1
       let l:snippet = s:Snippet.new(s:start_position, 'console.log(${1}${2})')
       let l:text = l:snippet.text()
       call s:expect(len(l:snippet.children)).to_equal(5)
@@ -235,7 +245,7 @@ Describe vsnip#snippet
       call s:expect(l:text).to_equal(l:snippet.text())
     End
 
-    It Should normalize 2
+    It should normalize 2
       let l:snippet = s:Snippet.new(s:start_position, 'console.log')
       call insert(l:snippet.children, vsnip#session#snippet#node#create_text('___'), 1)
       let l:text = l:snippet.text()
@@ -245,7 +255,7 @@ Describe vsnip#snippet
       call s:expect(l:text).to_equal(l:snippet.text())
     End
 
-    It Should normalize 3
+    It should normalize 3
       let l:snippet = s:Snippet.new(s:start_position, '${1:i}${2:++}')
       let l:children = deepcopy(l:snippet.children)
       call l:snippet.normalize()  " Don't change anything
@@ -256,32 +266,32 @@ Describe vsnip#snippet
 
   Describe #insert_node
 
-    It Should insert node 1
+    It should insert node 1
       let l:snippet = s:Snippet.new(s:start_position, 'console.log(${1}, ${2:${1}})')
       call l:snippet.insert_node({ 'line': 1, 'character': 13 }, s:Snippet.new(s:start_position, 'console.log(${3}, ${4:${3}})').children)
       call s:expect(l:snippet.text()).to_equal('console.log(console.log(, ), )')
     End
 
-    It Should insert node 2
+    It should insert node 2
       let l:snippet = s:Snippet.new(s:start_position, 'console.log(${1}, ${2:${1}})')
       call l:snippet.insert_node({ 'line': 1, 'character': 15 }, s:Snippet.new(s:start_position, 'console.log()').children)
       call s:expect(l:snippet.text()).to_equal('console.log(, console.log())')
       call s:expect(len(l:snippet.get_placeholder_nodes())).to_equal(5)
     End
 
-    It Should insert node 3
+    It should insert node 3
       let l:snippet = s:Snippet.new(s:start_position, 'console.log(aiueo)')
       call l:snippet.insert_node({ 'line': 1, 'character': 13 }, s:Snippet.new(s:start_position, '___').children)
       call s:expect(l:snippet.text()).to_equal('console.log(___aiueo)')
     End
 
-    It Should insert node 4
+    It should insert node 4
       let l:snippet = s:Snippet.new(s:start_position, 'console.log(aiueo)')
       call l:snippet.insert_node({ 'line': 1, 'character': 15 }, s:Snippet.new(s:start_position, '___').children)
       call s:expect(l:snippet.text()).to_equal('console.log(ai___ueo)')
     End
 
-    It Should insert node 5
+    It should insert node 5
       let l:snippet = s:Snippet.new(s:start_position, 'console.log(aiueo)')
       call l:snippet.insert_node({ 'line': 1, 'character': 18 }, [vsnip#session#snippet#node#create_text('___')])
       call s:expect(l:snippet.text()).to_equal('console.log(aiueo___)')
@@ -291,90 +301,90 @@ Describe vsnip#snippet
 
   Describe #get_next_jump_point
 
-    It Should return next jump point 1
+    It should return next jump point 1
       let l:snippet = s:Snippet.new(s:start_position, 'console.log(${1:012345})')
       call s:expect(l:snippet.get_next_jump_point(0).range).to_equal({
-            \   'start': {
-            \     'line': 1,
-            \     'character': 13
-            \   },
-            \   'end': {
-            \     'line': 1,
-            \     'character': 19
-            \   }
-            \ })
+      \   'start': {
+      \     'line': 1,
+      \     'character': 13
+      \   },
+      \   'end': {
+      \     'line': 1,
+      \     'character': 19
+      \   }
+      \ })
     End
 
-    It Should return next jump point 2
+    It should return next jump point 2
       let l:snippet = s:Snippet.new(s:start_position, 'console.log(${1:0123${2:456}7890})')
       call s:expect(l:snippet.get_next_jump_point(0).range).to_equal({
-            \   'start': {
-            \     'line': 1,
-            \     'character': 13
-            \   },
-            \   'end': {
-            \     'line': 1,
-            \     'character': 24
-            \   }
-            \ })
+      \   'start': {
+      \     'line': 1,
+      \     'character': 13
+      \   },
+      \   'end': {
+      \     'line': 1,
+      \     'character': 24
+      \   }
+      \ })
       call s:expect(l:snippet.get_next_jump_point(1).range).to_equal({
-            \   'start': {
-            \     'line': 1,
-            \     'character': 17,
-            \   },
-            \   'end': {
-            \     'line': 1,
-            \     'character': 20
-            \   }
-            \ })
+      \   'start': {
+      \     'line': 1,
+      \     'character': 17,
+      \   },
+      \   'end': {
+      \     'line': 1,
+      \     'character': 20
+      \   }
+      \ })
     End
 
-    It Should return next jump point 3
+    It should return next jump point 3
       let l:snippet = s:Snippet.new(s:start_position, 'console.log(${1:0${3:12}3${2:456}7890})')
       call s:expect(l:snippet.get_next_jump_point(0).range).to_equal({
-            \   'start': {
-            \     'line': 1,
-            \     'character': 13
-            \   },
-            \   'end': {
-            \     'line': 1,
-            \     'character': 24
-            \   }
-            \ })
+      \   'start': {
+      \     'line': 1,
+      \     'character': 13
+      \   },
+      \   'end': {
+      \     'line': 1,
+      \     'character': 24
+      \   }
+      \ })
       call s:expect(l:snippet.get_next_jump_point(1).range).to_equal({
-            \   'start': {
-            \     'line': 1,
-            \     'character': 17,
-            \   },
-            \   'end': {
-            \     'line': 1,
-            \     'character': 20
-            \   }
-            \ })
+      \   'start': {
+      \     'line': 1,
+      \     'character': 17,
+      \   },
+      \   'end': {
+      \     'line': 1,
+      \     'character': 20
+      \   }
+      \ })
       call s:expect(l:snippet.get_next_jump_point(2).range).to_equal({
-            \   'start': {
-            \     'line': 1,
-            \     'character': 14,
-            \   },
-            \   'end': {
-            \     'line': 1,
-            \     'character': 16
-            \   }
-            \ })
+      \   'start': {
+      \     'line': 1,
+      \     'character': 14,
+      \   },
+      \   'end': {
+      \     'line': 1,
+      \     'character': 16
+      \   }
+      \ })
     End
 
-    It Should return next jump point 4
+    It should return next jump point 4
       let l:snippet = s:Snippet.new(s:start_position, 'console.log(0${1}123456789${1}0)')
       call s:expect(l:snippet.get_next_jump_point(0).range).to_equal({
-            \   'start': {
-            \     'line': 1,
-            \     'character': 14
-            \   },
-            \   'end': {
-            \     'line': 1,
-            \     'character': 14
-            \   }
-            \ })
+      \   'start': {
+      \     'line': 1,
+      \     'character': 14
+      \   },
+      \   'end': {
+      \     'line': 1,
+      \     'character': 14
+      \   }
+      \ })
     End
 
   End

--- a/autoload/vsnip/session/snippet.vimspec
+++ b/autoload/vsnip/session/snippet.vimspec
@@ -131,22 +131,42 @@ Describe vsnip#snippet
       call s:expect(l:snippet.get_next_jump_point(1).placeholder.text()).to_equal('d___ult')
     End
 
-    It should follow when diff range and snippet range are empty
-      let l:snippet = s:Snippet.new(s:start_position, '')
-      call l:snippet.follow(0, {
+    It should prefer placeholder node than text node when both followable (left)
+      let l:snippet = s:Snippet.new(s:start_position, '[${1:text1}][${2:text2}][${3:text3}]')
+      call l:snippet.follow(1, {
       \   'range': {
       \     'start': {
       \       'line': 1,
-      \       'character': 1
+      \       'character': 9
       \     },
       \     'end': {
       \       'line': 1,
-      \       'character': 1
+      \       'character': 9
       \     }
       \   },
       \   'text': '___'
       \ })
-      call s:expect(l:snippet.text()).to_equal('___')
+      call s:expect(l:snippet.text()).to_equal('[text1][___text2][text3]')
+      call s:expect(l:snippet.children[3].text()).to_equal('___text2')
+    End
+
+    It should prefer placeholder node than text node when both followable (right)
+      let l:snippet = s:Snippet.new(s:start_position, '[${1:text1}][${2:text2}][${3:text3}]')
+      call l:snippet.follow(1, {
+      \   'range': {
+      \     'start': {
+      \       'line': 1,
+      \       'character': 14
+      \     },
+      \     'end': {
+      \       'line': 1,
+      \       'character': 14
+      \     }
+      \   },
+      \   'text': '___'
+      \ })
+      call s:expect(l:snippet.text()).to_equal('[text1][text2___][text3]')
+      call s:expect(l:snippet.children[3].text()).to_equal('text2___')
     End
 
   End

--- a/autoload/vsnip/session/snippet/node.vim
+++ b/autoload/vsnip/session/snippet/node.vim
@@ -28,8 +28,8 @@ endfunction
 "
 function! vsnip#session#snippet#node#create_text(text) abort
   return s:Text.new({
-        \   'type': 'text',
-        \   'raw': a:text,
-        \   'escaped': a:text
-        \ })
+  \   'type': 'text',
+  \   'raw': a:text,
+  \   'escaped': a:text
+  \ })
 endfunction

--- a/autoload/vsnip/session/snippet/node/placeholder.vim
+++ b/autoload/vsnip/session/snippet/node/placeholder.vim
@@ -1,3 +1,5 @@
+let s:max_tabstop = 1000000
+
 function! vsnip#session#snippet#node#placeholder#import() abort
   return s:Placeholder
 endfunction
@@ -8,20 +10,31 @@ let s:Placeholder = {}
 " new.
 "
 function! s:Placeholder.new(ast) abort
-  return extend(deepcopy(s:Placeholder), {
+  let l:node = extend(deepcopy(s:Placeholder), {
   \   'type': 'placeholder',
   \   'id': a:ast.id,
+  \   'is_final': a:ast.id == 0,
   \   'follower': v:false,
   \   'choice': get(a:ast, 'choice', []),
   \   'children': vsnip#session#snippet#node#create_from_ast(get(a:ast, 'children', [])),
   \ })
+
+  if l:node.is_final
+    let l:node.id = s:max_tabstop
+  endif
+
+  if len(l:node.children) == 0
+    let l:node.children = [vsnip#session#snippet#node#create_text('')]
+  endif
+
+  return l:node
 endfunction
 
 "
 " text.
 "
 function! s:Placeholder.text() abort
-  return join(map(copy(self.children), { k, v -> v.text() }), '')
+  return join(map(copy(self.children), 'v:val.text()'), '')
 endfunction
 
 "

--- a/autoload/vsnip/session/snippet/parser.vim
+++ b/autoload/vsnip/session/snippet/parser.vim
@@ -3,11 +3,15 @@
 " @see https://github.com/Microsoft/language-server-protocol/blob/master/snippetSyntax.md
 "
 function! vsnip#session#snippet#parser#parse(text) abort
-  let l:parsed = s:parser.parse(a:text, 0)
-  if !l:parsed[0]
-    throw json_encode({ 'text': a:text, 'result': l:parsed })
-  endif
-  return l:parsed[1]
+	if strlen(a:text) == 0
+		return []
+	endif
+
+	let l:parsed = s:parser.parse(a:text, 0)
+	if !l:parsed[0]
+		throw json_encode({ 'text': a:text, 'result': l:parsed })
+	endif
+	return l:parsed[1]
 endfunction
 
 let s:Combinator = vsnip#session#snippet#parser#combinator#import()
@@ -35,121 +39,121 @@ let s:pipe = s:token('|')
 let s:varname = s:pattern('[_[:alpha:]]\w*')
 let s:int = s:map(s:pattern('\d\+'), { value -> str2nr(value[0]) })
 let s:text = { stop -> s:map(
-      \   s:skip(stop),
-      \   { value -> {
-      \     'type': 'text',
-      \     'raw': value[0],
-      \     'escaped': value[1]
-      \   }
-      \ }) }
+\   s:skip(stop),
+\   { value -> {
+\     'type': 'text',
+\     'raw': value[0],
+\     'escaped': value[1]
+\   }
+\ }) }
 let s:regex = s:map(s:text(['/']), { value -> {
-      \   'type': 'regex',
-      \   'pattern': value.raw
-      \ } })
+\   'type': 'regex',
+\   'pattern': value.raw
+\ } })
 
 "
 " any (without text).
 "
 let s:any = s:or(
-      \   s:lazy({ -> s:choice }),
-      \   s:lazy({ -> s:variable }),
-      \   s:lazy({ -> s:tabstop }),
-      \   s:lazy({ -> s:placeholder }),
-      \ )
+\   s:lazy({ -> s:choice }),
+\   s:lazy({ -> s:variable }),
+\   s:lazy({ -> s:tabstop }),
+\   s:lazy({ -> s:placeholder }),
+\ )
 
 "
 " format.
 "
 let s:format1 = s:map(s:seq(s:dollar, s:int), { value -> {
-      \   'type': 'format',
-      \   'id': value[1]
-      \ } })
+\   'type': 'format',
+\   'id': value[1]
+\ } })
 let s:format2 = s:map(s:seq(s:dollar, s:open, s:int, s:close), { value -> {
-      \   'type': 'format',
-      \   'id': value[2]
-      \ } })
+\   'type': 'format',
+\   'id': value[2]
+\ } })
 let s:format3 = s:map(
-      \ s:seq(
-      \   s:dollar,
-      \   s:open,
-      \   s:int,
-      \   s:colon,
-      \   s:or(
-      \     s:token('/upcase'),
-      \     s:token('/downcase'),
-      \     s:token('/capitalize'),
-      \     s:token('+if'),
-      \     s:token('?if:else'),
-      \     s:token('-else'),
-      \     s:token('else')
-      \   ),
-      \   s:close
-      \ ), { value -> {
-      \   'type': 'format',
-      \   'id': value[2],
-      \   'modifier': value[4]
-      \ } })
+\ s:seq(
+\   s:dollar,
+\   s:open,
+\   s:int,
+\   s:colon,
+\   s:or(
+\     s:token('/upcase'),
+\     s:token('/downcase'),
+\     s:token('/capitalize'),
+\     s:token('+if'),
+\     s:token('?if:else'),
+\     s:token('-else'),
+\     s:token('else')
+\   ),
+\   s:close
+\ ), { value -> {
+\   'type': 'format',
+\   'id': value[2],
+\   'modifier': value[4]
+\ } })
 let s:format = s:or(s:format1, s:format2, s:format3)
 
 "
 " transform
 "
 let s:transform1 = s:map(s:seq(
-      \   s:slash,
-      \   s:regex,
-      \   s:slash,
-      \   s:format,
-      \   s:slash,
-      \   s:or(s:token('i'))
-      \ ), { value -> {
-      \   'type': 'transform',
-      \   'regex': value[1],
-      \   'format': value[3],
-      \   'option': value[5]
-      \ } })
+\   s:slash,
+\   s:regex,
+\   s:slash,
+\   s:format,
+\   s:slash,
+\   s:or(s:token('i'))
+\ ), { value -> {
+\   'type': 'transform',
+\   'regex': value[1],
+\   'format': value[3],
+\   'option': value[5]
+\ } })
 let s:transform2 = s:map(s:seq(
-      \   s:slash,
-      \   s:regex,
-      \   s:slash,
-      \   s:text(['/']),
-      \   s:slash,
-      \   s:or(s:token('i'))
-      \ ), { value -> {
-      \   'type': 'transform',
-      \   'regex': value[1],
-      \   'replace': value[3],
-      \   'option': value[5]
-      \ } })
+\   s:slash,
+\   s:regex,
+\   s:slash,
+\   s:text(['/']),
+\   s:slash,
+\   s:or(s:token('i'))
+\ ), { value -> {
+\   'type': 'transform',
+\   'regex': value[1],
+\   'replace': value[3],
+\   'option': value[5]
+\ } })
 let s:transform = s:or(s:transform1, s:transform2)
 
 "
 " variable
 "
 let s:variable1 = s:map(s:seq(s:dollar, s:varname), { value -> {
-      \   'type': 'variable',
-      \   'name': value[1]
-      \ } })
+\   'type': 'variable',
+\   'name': value[1]
+\ } })
 let s:variable2 = s:map(s:seq(s:dollar, s:open, s:varname, s:close), { value -> {
-      \   'type': 'variable',
-      \   'name': value[2]
-      \ } })
+\   'type': 'variable',
+\   'name': value[2]
+\ } })
 let s:variable3 = s:map(s:seq(
-      \   s:dollar,
-      \   s:open,
-      \   s:varname,
-      \   s:colon,
-      \   s:or(s:any, s:text(['$', '}'])),
-      \   s:close
-      \ ), { value -> {
-      \   'type': 'variable',
-      \   'name': value[2],
-      \   'children': [value[4]]
-      \ } })
+\   s:dollar,
+\   s:open,
+\   s:varname,
+\   s:colon,
+\   s:or(s:any, s:text(['$', '}'])),
+\   s:close
+\ ), { value -> {
+\   'type': 'variable',
+\   'name': value[2],
+\   'children': [value[4]]
+\ } })
 let s:variable4 = s:map(s:seq(s:dollar, s:open, s:varname, s:transform, s:close), { value -> {
-      \   'type': 'variable',
-      \   'name': value[2],
-      \   'transform': value[3]
-      \ } })
+\   'type': 'variable',
+\   'name': value[2],
+\   'transform': value[3]
+\ } })
 
 let s:variable = s:or(s:variable1, s:variable2, s:variable3, s:variable4)
 
@@ -157,58 +161,58 @@ let s:variable = s:or(s:variable1, s:variable2, s:variable3, s:variable4)
 " placeholder.
 "
 let s:placeholder = s:map(s:seq(
-      \   s:dollar,
-      \   s:open,
-      \   s:int,
-      \   s:colon,
-      \   s:many(s:or(s:any, s:text(['$', '}']))),
-      \   s:close
-      \ ), { value -> {
-      \   'type': 'placeholder',
-      \   'id': value[2],
-      \   'children': value[4]
-      \ } })
+\   s:dollar,
+\   s:open,
+\   s:int,
+\   s:colon,
+\   s:many(s:or(s:any, s:text(['$', '}']))),
+\   s:close
+\ ), { value -> {
+\   'type': 'placeholder',
+\   'id': value[2],
+\   'children': value[4]
+\ } })
 
 "
 " tabstop
 "
 let s:tabstop1 = s:map(s:seq(s:dollar, s:int), { value -> {
-      \   'type': 'placeholder',
-      \   'id': value[1],
-      \   'children': [],
-      \ } })
+\   'type': 'placeholder',
+\   'id': value[1],
+\   'children': [],
+\ } })
 let s:tabstop2 = s:map(s:seq(s:dollar, s:open, s:int, s:option(s:colon), s:close), { value -> {
-      \   'type': 'placeholder',
-      \   'id': value[2],
-      \   'children': [],
-      \ } })
+\   'type': 'placeholder',
+\   'id': value[2],
+\   'children': [],
+\ } })
 let s:tabstop3 = s:map(s:seq(s:dollar, s:open, s:int, s:transform, s:close), { value -> {
-      \   'type': 'placeholder',
-      \   'id': value[2],
-      \   'children': [],
-      \   'transform': value[3]
-      \ } })
+\   'type': 'placeholder',
+\   'id': value[2],
+\   'children': [],
+\   'transform': value[3]
+\ } })
 let s:tabstop = s:or(s:tabstop1, s:tabstop2, s:tabstop3)
 
 "
 " choice
 "
 let s:choice = s:map(s:seq(
-      \   s:dollar,
-      \   s:open,
-      \   s:int,
-      \   s:pipe,
-      \   s:many(
-      \     s:map(s:seq(s:text([',', '|']), s:option(s:comma)), { value -> value[0] }),
-      \   ),
-      \   s:pipe,
-      \   s:close
-      \ ), { value -> {
-      \   'type': 'placeholder',
-      \   'id': value[2],
-      \   'choice': value[4],
-      \   'children': [copy(value[4][0])],
-      \ } })
+\   s:dollar,
+\   s:open,
+\   s:int,
+\   s:pipe,
+\   s:many(
+\     s:map(s:seq(s:text([',', '|']), s:option(s:comma)), { value -> value[0] }),
+\   ),
+\   s:pipe,
+\   s:close
+\ ), { value -> {
+\   'type': 'placeholder',
+\   'id': value[2],
+\   'choice': value[4],
+\   'children': [copy(value[4][0])],
+\ } })
 
 "
 " parser.

--- a/autoload/vsnip/session/snippet/parser.vimspec
+++ b/autoload/vsnip/session/snippet/parser.vimspec
@@ -4,164 +4,164 @@ Describe vsnip#session#snippet#parser
 
   Describe #parse
 
-    It Should parse text
+    It should parse text
       let l:parsed = vsnip#session#snippet#parser#parse('console.log()')
       call s:expect(len(l:parsed)).to_equal(1)
       call s:expect(l:parsed[0]).to_equal({
-            \   'type': 'text',
-            \   'raw': 'console.log()',
-            \   'escaped': 'console.log()'
-            \ })
+      \   'type': 'text',
+      \   'raw': 'console.log()',
+      \   'escaped': 'console.log()'
+      \ })
     End
 
-    It Should tabstop
+    It should tabstop
       let l:parsed = vsnip#session#snippet#parser#parse('console.log($0$1)')
       call s:expect(len(l:parsed)).to_equal(4)
       call s:expect(l:parsed[0]).to_equal({
-            \   'type': 'text',
-            \   'raw': 'console.log(',
-            \   'escaped': 'console.log('
-            \ })
+      \   'type': 'text',
+      \   'raw': 'console.log(',
+      \   'escaped': 'console.log('
+      \ })
       call s:expect(l:parsed[1]).to_equal({
-            \   'type': 'placeholder',
-            \   'id': 0,
-            \   'children': []
-            \ })
+      \   'type': 'placeholder',
+      \   'id': 0,
+      \   'children': []
+      \ })
       call s:expect(l:parsed[2]).to_equal({
-            \   'type': 'placeholder',
-            \   'id': 1,
-            \   'children': []
-            \ })
+      \   'type': 'placeholder',
+      \   'id': 1,
+      \   'children': []
+      \ })
       call s:expect(l:parsed[3]).to_equal({
-            \   'type': 'text',
-            \   'raw': ')',
-            \   'escaped': ')'
-            \ })
+      \   'type': 'text',
+      \   'raw': ')',
+      \   'escaped': ')'
+      \ })
     End
 
-    It Should parse choice
+    It should parse choice
       let l:parsed = vsnip#session#snippet#parser#parse("${1|log,warn,error|}")
       call s:expect(l:parsed[0]).to_equal({
-            \   'type': 'placeholder',
-            \   'id': 1,
-            \   'choice': [{
-            \     'type': 'text',
-            \     'raw': 'log',
-            \     'escaped': 'log'
-            \   }, {
-            \     'type': 'text',
-            \     'raw': 'warn',
-            \     'escaped': 'warn'
-            \   }, {
-            \     'type': 'text',
-            \     'raw': 'error',
-            \     'escaped': 'error'
-            \   }],
-            \   'children': [{
-            \     'type': 'text',
-            \     'raw': 'log',
-            \     'escaped': 'log'
-            \   }]
-            \ })
+      \   'type': 'placeholder',
+      \   'id': 1,
+      \   'choice': [{
+      \     'type': 'text',
+      \     'raw': 'log',
+      \     'escaped': 'log'
+      \   }, {
+      \     'type': 'text',
+      \     'raw': 'warn',
+      \     'escaped': 'warn'
+      \   }, {
+      \     'type': 'text',
+      \     'raw': 'error',
+      \     'escaped': 'error'
+      \   }],
+      \   'children': [{
+      \     'type': 'text',
+      \     'raw': 'log',
+      \     'escaped': 'log'
+      \   }]
+      \ })
     End
 
-    It Should parse escaped text 1
+    It should parse escaped text 1
       let l:parsed = vsnip#session#snippet#parser#parse('${1:\\\$variable\}}')
       call s:expect(len(l:parsed)).to_equal(1)
       call s:expect(l:parsed[0]).to_equal({
-            \   'type': 'placeholder',
-            \   'id': 1,
-            \   'children': [{
-            \     'type': 'text',
-            \     'raw': '\\\$variable\}',
-            \     'escaped': '\$variable}'
-            \   }]
-            \ })
+      \   'type': 'placeholder',
+      \   'id': 1,
+      \   'children': [{
+      \     'type': 'text',
+      \     'raw': '\\\$variable\}',
+      \     'escaped': '\$variable}'
+      \   }]
+      \ })
     End
 
-    It Should parse escaped text 2
+    It should parse escaped text 2
       let l:parsed = vsnip#session#snippet#parser#parse('${1:{\}}')
       call s:expect(len(l:parsed)).to_equal(1)
       call s:expect(l:parsed[0]).to_equal({
-            \   'type': 'placeholder',
-            \   'id': 1,
-            \   'children': [{
-            \     'type': 'text',
-            \     'raw': '{\}',
-            \     'escaped': '{}'
-            \   }]
-            \ })
+      \   'type': 'placeholder',
+      \   'id': 1,
+      \   'children': [{
+      \     'type': 'text',
+      \     'raw': '{\}',
+      \     'escaped': '{}'
+      \   }]
+      \ })
     End
 
-    It Should parse escaped text 3
+    It should parse escaped text 3
       let l:parsed = vsnip#session#snippet#parser#parse('\{\}')
       call s:expect(len(l:parsed)).to_equal(1)
       call s:expect(l:parsed[0]).to_equal({
-            \   'type': 'text',
-            \   'raw': '\{\}',
-            \   'escaped': '{}'
-            \ })
+      \   'type': 'text',
+      \   'raw': '\{\}',
+      \   'escaped': '{}'
+      \ })
     End
 
-    It Should parse nested placeholder
+    It should parse nested placeholder
       let l:parsed = vsnip#session#snippet#parser#parse('class $1${2: extends ${3:SuperClass}} { $0 }')
       call s:expect(len(l:parsed)).to_equal(6)
       call s:expect(l:parsed[0]).to_equal({
-            \   'type': 'text',
-            \   'raw': 'class ',
-            \   'escaped': 'class '
-            \ })
+      \   'type': 'text',
+      \   'raw': 'class ',
+      \   'escaped': 'class '
+      \ })
       call s:expect(l:parsed[1]).to_equal({
-            \   'type': 'placeholder',
-            \   'id': 1,
-            \   'children': []
-            \ })
+      \   'type': 'placeholder',
+      \   'id': 1,
+      \   'children': []
+      \ })
       call s:expect(l:parsed[2]).to_equal({
-            \   'type': 'placeholder',
-            \   'id': 2,
-            \   'children': [{
-            \     'type': 'text',
-            \     'raw': ' extends ',
-            \     'escaped': ' extends '
-            \   }, {
-            \     'type': 'placeholder',
-            \     'id': 3,
-            \     'children': [{
-            \       'type': 'text',
-            \       'raw': 'SuperClass',
-            \       'escaped': 'SuperClass'
-            \     }]
-            \   }]
-            \ })
+      \   'type': 'placeholder',
+      \   'id': 2,
+      \   'children': [{
+      \     'type': 'text',
+      \     'raw': ' extends ',
+      \     'escaped': ' extends '
+      \   }, {
+      \     'type': 'placeholder',
+      \     'id': 3,
+      \     'children': [{
+      \       'type': 'text',
+      \       'raw': 'SuperClass',
+      \       'escaped': 'SuperClass'
+      \     }]
+      \   }]
+      \ })
       call s:expect(l:parsed[3]).to_equal({
-            \   'type': 'text',
-            \   'raw': ' { ',
-            \   'escaped': ' { '
-            \ })
+      \   'type': 'text',
+      \   'raw': ' { ',
+      \   'escaped': ' { '
+      \ })
       call s:expect(l:parsed[4]).to_equal({
-            \   'type': 'placeholder',
-            \   'id': 0,
-            \   'children': []
-            \ })
+      \   'type': 'placeholder',
+      \   'id': 0,
+      \   'children': []
+      \ })
       call s:expect(l:parsed[5]).to_equal({
-            \   'type': 'text',
-            \   'raw': ' }',
-            \   'escaped': ' }'
-            \ })
+      \   'type': 'text',
+      \   'raw': ' }',
+      \   'escaped': ' }'
+      \ })
     End
 
-    It Should parse variable
+    It should parse variable
       let l:parsed = vsnip#session#snippet#parser#parse('${variable:default}')
       call s:expect(len(l:parsed)).to_equal(1)
       call s:expect(l:parsed[0]).to_equal({
-            \   'type': 'variable',
-            \   'name': 'variable',
-            \   'children': [{
-            \     'type': 'text',
-            \     'raw': 'default',
-            \     'escaped': 'default',
-            \   }]
-            \ })
+      \   'type': 'variable',
+      \   'name': 'variable',
+      \   'children': [{
+      \     'type': 'text',
+      \     'raw': 'default',
+      \     'escaped': 'default',
+      \   }]
+      \ })
     End
 
   End

--- a/autoload/vsnip/session/snippet/parser/combinator.vim
+++ b/autoload/vsnip/session/snippet/parser/combinator.vim
@@ -1,15 +1,15 @@
 function! vsnip#session#snippet#parser#combinator#import() abort
   return {
-        \   'skip': function('s:skip'),
-        \   'token': function('s:token'),
-        \   'many': function('s:many'),
-        \   'or': function('s:or'),
-        \   'seq': function('s:seq'),
-        \   'pattern': function('s:pattern'),
-        \   'lazy': function('s:lazy'),
-        \   'option': function('s:option'),
-        \   'map': function('s:map')
-        \ }
+  \   'skip': function('s:skip'),
+  \   'token': function('s:token'),
+  \   'many': function('s:many'),
+  \   'or': function('s:or'),
+  \   'seq': function('s:seq'),
+  \   'pattern': function('s:pattern'),
+  \   'lazy': function('s:lazy'),
+  \   'option': function('s:option'),
+  \   'map': function('s:map')
+  \ }
 endfunction
 
 "

--- a/autoload/vsnip/source.vim
+++ b/autoload/vsnip/source.vim
@@ -93,8 +93,8 @@ function! s:resolve_prefix(prefix) abort
   endfor
 
   return [
-        \   sort(l:prefixes, { a, b -> strlen(b) - strlen(a) }),
-        \   sort(l:prefixes_alias, { a, b -> strlen(b) - strlen(a) })
-        \ ]
+  \   sort(l:prefixes, { a, b -> strlen(b) - strlen(a) }),
+  \   sort(l:prefixes_alias, { a, b -> strlen(b) - strlen(a) })
+  \ ]
 endfunction
 

--- a/autoload/vsnip/source/vscode.vim
+++ b/autoload/vsnip/source/vscode.vim
@@ -46,7 +46,7 @@ function! s:find(language) abort
 
       " if package.json has not `contributes.snippets` fields, skip it.
       if !has_key(l:package_json, 'contributes')
-            \ || !has_key(l:package_json.contributes, 'snippets')
+      \ || !has_key(l:package_json.contributes, 'snippets')
         continue
       endif
 
@@ -60,9 +60,9 @@ function! s:find(language) abort
         endif
 
         let s:snippets[l:path] = {
-              \   'languages': type(l:snippet.language) == type([]) ? l:snippet.language : [l:snippet.language],
-              \   'source': vsnip#source#create(l:path)
-              \ }
+        \   'languages': type(l:snippet.language) == type([]) ? l:snippet.language : [l:snippet.language],
+        \   'source': vsnip#source#create(l:path)
+        \ }
       endfor
     catch /.*/
     endtry
@@ -83,8 +83,8 @@ endfunction
 "
 function! s:get_language(filetype) abort
   return get({
-        \   'javascript.jsx': 'javascriptreact',
-        \   'typescript.tsx': 'typescriptreact',
-        \ }, a:filetype, a:filetype)
+  \   'javascript.jsx': 'javascriptreact',
+  \   'typescript.tsx': 'typescriptreact',
+  \ }, a:filetype, a:filetype)
 endfunction
 

--- a/doc/vsnip.txt
+++ b/doc/vsnip.txt
@@ -31,7 +31,7 @@ You can use your favorite plugin manager.
   NeoBundle 'hrsh7th/vim-vsnip'
 <
 
-If you use `deoplete.nvim`, you can use `vim-vsnip-integ`.
+If you use `deoplete.nvim` or other supported integration, you can use `vim-vsnip-integ`.
 
 >
   " dein.vim
@@ -44,7 +44,7 @@ If you use `deoplete.nvim`, you can use `vim-vsnip-integ`.
   NeoBundle 'hrsh7th/vim-vsnip-integ'
 <
 
-`vim-vsnip-integ` will supports other plugin integrations.
+If you want to know supported plugins, you can see https://github.com/hrsh7th/vim-vsnip-integ
 
 
 ==============================================================================
@@ -97,19 +97,28 @@ You can use your favorite key to expand or jump snippet.
 The below example uses '<Tab>' key.
 
 >
-  imap <expr> <C-j>   vsnip#available(1)  ? '<Plug>(vsnip-expand)'         : '<C-j>'
-  smap <expr> <C-j>   vsnip#expandable(1) ? '<Plug>(vsnip-expand)'         : '<C-j>'
-  imap <expr> <C-l>   vsnip#available(1)  ? '<Plug>(vsnip-expand-or-jump)' : '<C-l>'
-  imap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
-  smap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
-  imap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
-  smap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
-  nmap        <C-j>   <Plug>(vsnip-cut-text)
-  xmap        <C-j>   <Plug>(vsnip-cut-text)
-  smap        <C-j>   <Plug>(vsnip-cut-text)
-  nmap        <C-l>   <Plug>(vsnip-select-text)
-  xmap        <C-l>   <Plug>(vsnip-select-text)
-  smap        <C-l>   <Plug>(vsnip-select-text)
+    " Expand
+    imap <expr> <C-j>   vsnip#available(1)  ? '<Plug>(vsnip-expand)'         : '<C-j>'
+    smap <expr> <C-j>   vsnip#expandable()  ? '<Plug>(vsnip-expand)'         : '<C-j>'
+
+    " Expand or jump
+    imap <expr> <C-l>   vsnip#available(1)  ? '<Plug>(vsnip-expand-or-jump)' : '<C-l>'
+    smap <expr> <C-l>   vsnip#available(1)  ? '<Plug>(vsnip-expand-or-jump)' : '<C-l>'
+
+    " Jump forward or backward
+    imap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
+    smap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
+    imap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
+    smap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
+
+    " Select or cut text to use as $TM_SELECTED_TEXT in the next snippet.
+    " See https://github.com/hrsh7th/vim-vsnip/pull/50
+    nmap        <C-l>   <Plug>(vsnip-select-text)
+    xmap        <C-l>   <Plug>(vsnip-select-text)
+    smap        <C-l>   <Plug>(vsnip-select-text)
+    nmap        <C-j>   <Plug>(vsnip-cut-text)
+    xmap        <C-j>   <Plug>(vsnip-cut-text)
+    smap        <C-j>   <Plug>(vsnip-cut-text)
 <
 
 

--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -41,9 +41,9 @@ function! s:open_command(bang, cmd)
   endif
 
   execute printf('%s %s', a:cmd, fnameescape(printf('%s/%s.json',
-        \   g:vsnip_snippet_dir,
-        \   l:candidates[l:idx - 1]
-        \ )))
+  \   g:vsnip_snippet_dir,
+  \   l:candidates[l:idx - 1]
+  \ )))
 endfunction
 
 "
@@ -139,7 +139,7 @@ function! s:vsnip_set_text(type, copy) abort
   elseif a:type ==? ''
     let select = '`<`>"v'
   elseif a:type ==# 'char'
-        \ || (a:type ==# 'line' && s:virtualedit_in_normal())
+  \ || (a:type ==# 'line' && s:virtualedit_in_normal())
     let select = '`[v`]"v'
   elseif a:type ==# 'line'
     let select = "'[V']\"v"


### PR DESCRIPTION
## Overview
#### s:Snippet.follow
- Join `search candidates` and `narrowing candidates` to one pass.

#### s:Snippet.sync
- Separate `initialize` related codes to `s:Snippet.init`
- Avoid traverse twice.
- Avoid creating needless text_edits 

## TODO
- [x] Make codes readable
- [ ] ~~Refactor `s:Snippet.init`~~ hard to fix
- [x] Add tests for `s:Snippet.init` and `s:Snippet.sync`
- [x] Check perf

## diff
https://github.com/hrsh7th/vim-vsnip/pull/60/files?w=1