### PR TITLE
Strict prefix matching

### DIFF
--- a/autoload/vsnip.vim
+++ b/autoload/vsnip.vim
@@ -99,31 +99,19 @@ endfunction
 "
 function! vsnip#get_context() abort
   let l:before_text = getline('.')[0 : col('.') - 2]
+  let l:before_text_len = strchars(l:before_text)
   for l:source in vsnip#source#find(&filetype)
     for l:snippet in l:source
       for l:prefix in (l:snippet.prefix + l:snippet.prefix_alias)
-        let l:match = matchlist(l:before_text, printf('\%(\(\k\+\)\V%s\m\)\=\<\(\V%s\m\)\>$',
-              \   escape(g:vsnip_auto_select_trigger, '\'),
-              \   escape(l:prefix, '\'),
-              \ ))
-
-        " check match.
-        if len(l:match) == 0 || l:match[3] ==# ''
+        let l:prefix_len = strchars(l:prefix)
+        if strcharpart(l:before_text, l:before_text_len - l:prefix_len, l:prefix_len) !=# l:prefix
           continue
         endif
 
-        " check selected text.
-        let l:length = strchars(l:prefix)
-        if l:match[2] !=# ''
-          let l:length += 1
-          let l:length += strchars(l:match[2])
-          call vsnip#selected_text(l:match[2])
-        endif
-
         return {
-              \   'length': l:length,
-              \   'snippet': l:snippet
-              \ }
+        \   'length': l:prefix_len,
+        \   'snippet': l:snippet
+        \ }
       endfor
     endfor
   endfor

--- a/doc/vsnip.txt
+++ b/doc/vsnip.txt
@@ -83,12 +83,6 @@ VARIABLE                                                      *vsnip-variable*
 
 
 >
-  let g:vsnip_auto_select_trigger = ';'
-<
-    Specify auto select trigger character.
-
-
->
   let g:vsnip_namespace = ''
 <
     Specify all snippet prefix's prefix.

--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -11,7 +11,6 @@ let g:vsnip_snippet_dir = get(g:, 'vsnip_snippet_dir', expand('~/.vsnip'))
 let g:vsnip_snippet_dirs = get(g:, 'vsnip_snippet_dirs', [])
 let g:vsnip_sync_delay = get(g:, 'vsnip_sync_delay', 0)
 let g:vsnip_choice_delay = get(g:, 'vsnip_choice_delay', 500)
-let g:vsnip_auto_select_trigger = get(g:, 'vsnip_auto_select_trigger', ';')
 let g:vsnip_namespace = get(g:, 'vsnip_namespace', '')
 
 "


### PR DESCRIPTION
Fixes #62

This PR aims to improve prefix detection at snippet expansion.

And this PR has a breaking change that is removing `auto_select_trigger` feature.

In my knowledge, there are no users of using this feature.
If someone raises the request to leave this feature, I will re-implement it.
