### PR TITLE
Fix smap <Plug>(vsnip-expand)

### DIFF
--- a/autoload/vsnip.vim
+++ b/autoload/vsnip.vim
@@ -98,7 +98,7 @@ endfunction
 " get_context.
 "
 function! vsnip#get_context() abort
-  let l:offset = mode() ==# 's' ? 1 : 2
+  let l:offset = mode()[0] ==# 'i' ? 2 : 1
   let l:before_text = getline('.')[0 : col('.') - l:offset]
   let l:before_text_len = strchars(l:before_text)
   for l:source in vsnip#source#find(&filetype)

--- a/autoload/vsnip.vim
+++ b/autoload/vsnip.vim
@@ -98,7 +98,8 @@ endfunction
 " get_context.
 "
 function! vsnip#get_context() abort
-  let l:before_text = getline('.')[0 : col('.') - 2]
+  let l:offset = mode() ==# 's' ? 1 : 2
+  let l:before_text = getline('.')[0 : col('.') - l:offset]
   let l:before_text_len = strchars(l:before_text)
   for l:source in vsnip#source#find(&filetype)
     for l:snippet in l:source

--- a/autoload/vsnip/session.vim
+++ b/autoload/vsnip/session.vim
@@ -159,7 +159,7 @@ function! s:Session.select(jump_point) abort
   else
     let l:cmd .= 'v'
   endif
-  let l:cmd .= "\<C-g>"
+  let l:cmd .= "o\<C-g>"
   call feedkeys(l:cmd, 'nt')
 endfunction
 

--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -76,7 +76,7 @@ endfunction
 " <Plug>(vsnip-expand)
 "
 inoremap <silent> <Plug>(vsnip-expand) <Esc>:<C-u>call <SID>expand()<CR>
-snoremap <silent> <Plug>(vsnip-expand) <C-g>o<Esc>:<C-u>call <SID>expand()<CR>
+snoremap <silent> <Plug>(vsnip-expand) <C-g><Esc>:<C-u>call <SID>expand()<CR>
 function! s:expand() abort
   let l:ctx = {}
   function! l:ctx.callback() abort


### PR DESCRIPTION
A recent commit introduced a regression for the newly introduced
<Plug>(vsnip-expand) mapping. (#51)
I've changed a few spots to make this mapping more robust.

The context for the snippet was detected incorrectly as the current
column was at the beginning of the selection and no snippet could be
detected.

Now the selected text will have the cursor at the end instead of the
front.
This change will probably affect no user and eases the
implementation.

Also the column offset in select mode is 1 instead of 2.

Now the implementation of <Plug>(vsnip-expand) should be fully supported
instead of "just works".