### PR TITLE
Fix context for select mode

### DIFF
--- a/autoload/vsnip.vim
+++ b/autoload/vsnip.vim
@@ -96,7 +96,7 @@ endfunction
 " get_context.
 "
 function! vsnip#get_context() abort
-  let l:offset = mode()[0] ==# 'i' ? 2 : 1
+  let l:offset = mode()[0] ==# 's' ? 1 : 2
   let l:before_text = getline('.')[0 : col('.') - l:offset]
   let l:before_text_len = strchars(l:before_text)
   for l:source in vsnip#source#find(&filetype)

--- a/autoload/vsnip.vim
+++ b/autoload/vsnip.vim
@@ -96,7 +96,8 @@ endfunction
 " get_context.
 "
 function! vsnip#get_context() abort
-  let l:before_text = getline('.')[0 : col('.') - 2]
+  let l:offset = mode()[0] ==# 'i' ? 2 : 1
+  let l:before_text = getline('.')[0 : col('.') - l:offset]
   let l:before_text_len = strchars(l:before_text)
   for l:source in vsnip#source#find(&filetype)
     for l:snippet in l:source


### PR DESCRIPTION
Follow up to #64 

I hadn't tested with a character after the cursor.
Should work as expected now:

`_prefix|_` now expands in insert
`_|prefix|_` still expands in select

_noprefix|_ still jumps in insert
_|noprefix|_ still jumps in select