### PR TITLE
Improve suggested key mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ NeoBundle 'hrsh7th/vim-vsnip-integ'
 " NOTE: You can use other key to expand snippet.
 
 " Expand
-imap <expr> <C-j>   vsnip#available(1)  ? '<Plug>(vsnip-expand)'         : '<C-j>'
+imap <expr> <C-j>   vsnip#expandable()  ? '<Plug>(vsnip-expand)'         : '<C-j>'
 smap <expr> <C-j>   vsnip#expandable()  ? '<Plug>(vsnip-expand)'         : '<C-j>'
 
 " Expand or jump
@@ -70,10 +70,10 @@ imap <expr> <C-l>   vsnip#available(1)  ? '<Plug>(vsnip-expand-or-jump)' : '<C-l
 smap <expr> <C-l>   vsnip#available(1)  ? '<Plug>(vsnip-expand-or-jump)' : '<C-l>'
 
 " Jump forward or backward
-imap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
-smap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
-imap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
-smap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
+imap <expr> <Tab>   vsnip#jumpable(1)   ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
+smap <expr> <Tab>   vsnip#jumpable(1)   ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
+imap <expr> <S-Tab> vsnip#jumpable(-1)  ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
+smap <expr> <S-Tab> vsnip#jumpable(-1)  ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
 
 " Select or cut text to use as $TM_SELECTED_TEXT in the next snippet.
 " See https://github.com/hrsh7th/vim-vsnip/pull/50

--- a/autoload/vsnip.vim
+++ b/autoload/vsnip.vim
@@ -21,9 +21,7 @@ endfunction
 "
 function! vsnip#available(...) abort
   let l:direction = get(a:000, 0, 1)
-  let l:expandable = vsnip#expandable()
-  let l:jumpable = !empty(s:session) && s:session.jumpable(l:direction)
-  return l:expandable || l:jumpable
+  return vsnip#expandable() || vsnip#jumpable(l:direction)
 endfunction
 
 "
@@ -31,6 +29,14 @@ endfunction
 "
 function! vsnip#expandable() abort
   return !empty(vsnip#get_context())
+endfunction
+
+"
+" vsnip#jumpable.
+"
+function! vsnip#jumpable(...) abort
+  let l:direction = get(a:000, 0, 1)
+  return !empty(s:session) && s:session.jumpable(l:direction)
 endfunction
 
 "

--- a/doc/vsnip.txt
+++ b/doc/vsnip.txt
@@ -98,7 +98,7 @@ The below example uses '<Tab>' key.
 
 >
     " Expand
-    imap <expr> <C-j>   vsnip#available(1)  ? '<Plug>(vsnip-expand)'         : '<C-j>'
+    imap <expr> <C-j>   vsnip#expandable()  ? '<Plug>(vsnip-expand)'         : '<C-j>'
     smap <expr> <C-j>   vsnip#expandable()  ? '<Plug>(vsnip-expand)'         : '<C-j>'
 
     " Expand or jump
@@ -106,10 +106,10 @@ The below example uses '<Tab>' key.
     smap <expr> <C-l>   vsnip#available(1)  ? '<Plug>(vsnip-expand-or-jump)' : '<C-l>'
 
     " Jump forward or backward
-    imap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
-    smap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
-    imap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
-    smap <expr> <S-Tab> vsnip#available(-1) ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
+    imap <expr> <Tab>   vsnip#jumpable(1)   ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
+    smap <expr> <Tab>   vsnip#jumpable(1)   ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
+    imap <expr> <S-Tab> vsnip#jumpable(-1)  ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
+    smap <expr> <S-Tab> vsnip#jumpable(-1)  ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
 
     " Select or cut text to use as $TM_SELECTED_TEXT in the next snippet.
     " See https://github.com/hrsh7th/vim-vsnip/pull/50


### PR DESCRIPTION
The current suggested key mappings have an issue as they test for jump
and expansion.

### Examples
#### 1
```viml
imap <expr> <C-j>   vsnip#available(1)  ? '<Plug>(vsnip-expand)'         : '<TAB>'
imap <expr> <C-l>   vsnip#expandable()  ? '<Plug>(vsnip-expand)'         : '<TAB>'
```
Inside of an expanded snippet:
`___noprefix|<C-j>` -> `___noprefix|`
`___noprefix|<C-l>` -> `___noprefix    |`

#### 2
```viml
imap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
```
`___prefix|<TAB>` -> `___prefix|`

```viml
imap <expr> <Tab>   vsnip#jumpable(1)   ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
```
`___prefix|<TAB>` -> `___prefix    |`