### PR TITLE
Improve get_context implementation

### DIFF
--- a/.themisrc
+++ b/.themisrc
@@ -1,3 +1,13 @@
 call themis#option('recursive', 1)
 call themis#option('exclude', '\.vim$')
 
+let g:vsnip_snippet_dir = fnamemodify(expand('<sfile>'), ':h') . '/misc'
+
+imap <expr> <C-j>   vsnip#expandable()  ? '<Plug>(vsnip-expand)'         : '<C-j>'
+smap <expr> <C-j>   vsnip#expandable()  ? '<Plug>(vsnip-expand)'         : '<C-j>'
+
+imap <expr> <Tab>   vsnip#available(1)  ? '<Plug>(vsnip-expand-or-jump)' : '<Tab>'
+smap <expr> <Tab>   vsnip#jumpable(1)   ? '<Plug>(vsnip-jump-next)'      : '<Tab>'
+imap <expr> <S-Tab> vsnip#jumpable(-1)  ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
+smap <expr> <S-Tab> vsnip#jumpable(-1)  ? '<Plug>(vsnip-jump-prev)'      : '<S-Tab>'
+

--- a/autoload/vsnip.vim
+++ b/autoload/vsnip.vim
@@ -45,21 +45,25 @@ endfunction
 function! vsnip#expand() abort
   let l:context = vsnip#get_context()
   if !empty(l:context)
-    let l:text_edit = {
+    call s:TextEdit.apply(bufnr('%'), [{
     \   'range': l:context.range,
     \   'newText': ''
-    \ }
-    call s:TextEdit.apply(bufnr('%'), [l:text_edit])
-    call cursor(s:Position.lsp_to_vim('%', l:context.range.start))
-    call vsnip#anonymous(join(l:context.snippet.body, "\n"))
+    \ }])
+    call vsnip#anonymous(join(l:context.snippet.body, "\n"), {
+    \   'position': l:context.range.start
+    \ })
   endif
 endfunction
 
 "
 " vsnip#anonymous.
 "
-function! vsnip#anonymous(text) abort
-  let l:session = s:Session.new(bufnr('%'), s:Position.cursor(), a:text)
+function! vsnip#anonymous(text, ...) abort
+  let l:option = get(a:000, 0, {})
+  let l:position = get(l:option, 'position', s:Position.cursor())
+
+  let l:session = s:Session.new(bufnr('%'), l:position, a:text)
+
   call vsnip#selected_text('')
 
   if !empty(s:session)

--- a/autoload/vsnip.vim
+++ b/autoload/vsnip.vim
@@ -102,11 +102,15 @@ function! vsnip#get_context() abort
   let l:offset = mode()[0] ==# 'i' ? 2 : 1
   let l:before_text = getline('.')[0 : col('.') - l:offset]
   let l:before_text_len = strchars(l:before_text)
+
+  if l:before_text_len == 0
+    return {}
+  endif
+
   for l:source in vsnip#source#find(&filetype)
     for l:snippet in l:source
       for l:prefix in (l:snippet.prefix + l:snippet.prefix_alias)
-        let l:prefix_len = strchars(l:prefix)
-        if strcharpart(l:before_text, l:before_text_len - l:prefix_len, l:prefix_len) !=# l:prefix
+        if l:before_text !~# '\<\V' . escape(l:prefix, '\/?') . '\m\>$'
           continue
         endif
 
@@ -115,7 +119,7 @@ function! vsnip#get_context() abort
         \   'range': {
         \     'start': {
         \       'line': l:line,
-        \       'character': l:before_text_len - l:prefix_len,
+        \       'character': l:before_text_len - strchars(l:prefix),
         \     },
         \     'end': {
         \       'line': l:line,

--- a/autoload/vsnip.vimspec
+++ b/autoload/vsnip.vimspec
@@ -1,0 +1,98 @@
+let s:expect = themis#helper('expect')
+
+Describe vsnip
+
+  Describe #get_context
+
+    It should return context information in insert-mode
+      function! Test()
+        call s:expect(mode(1)).to_equal('i')
+        call s:expect(vsnip#get_context()).to_equal({
+        \   'range': {
+        \     'start': {
+        \       'line': 0,
+        \       'character': 0,
+        \     },
+        \     'end': {
+        \       'line': 0,
+        \       'character': 5,
+        \     },
+        \   },
+        \   'snippet': {
+        \     'label': 'Test1',
+        \     'description': '',
+        \     'prefix': ['test1'],
+        \     'prefix_alias': [],
+        \     'body': [
+        \       'snippet'
+        \     ],
+        \   }
+        \ })
+      endfunction
+      enew!
+      call setline(1, 'test1')
+      call cursor([1, 5])
+      call feedkeys("a\<C-r>=Test()\<CR>", 'x')
+    End
+
+    It should return context information in normal-mode
+      enew!
+      call setline(1, 'test1')
+      call cursor([1, 5])
+      call s:expect(mode(1)).to_equal('n')
+      call s:expect(vsnip#get_context()).to_equal({
+      \   'range': {
+      \     'start': {
+      \       'line': 0,
+      \       'character': 0,
+      \     },
+      \     'end': {
+      \       'line': 0,
+      \       'character': 5,
+      \     },
+      \   },
+      \   'snippet': {
+      \     'label': 'Test1',
+      \     'description': '',
+      \     'prefix': ['test1'],
+      \     'prefix_alias': [],
+      \     'body': [
+      \       'snippet'
+      \     ],
+      \   }
+      \ })
+    End
+
+    It should return context information in select-mode
+      enew!
+      call setline(1, 'test1')
+      call feedkeys("v\<C-g>", 'x')
+      call cursor([1, 5])
+      call s:expect(mode(1)).to_equal('s')
+      call s:expect(vsnip#get_context()).to_equal({
+      \   'range': {
+      \     'start': {
+      \       'line': 0,
+      \       'character': 0,
+      \     },
+      \     'end': {
+      \       'line': 0,
+      \       'character': 5,
+      \     },
+      \   },
+      \   'snippet': {
+      \     'label': 'Test1',
+      \     'description': '',
+      \     'prefix': ['test1'],
+      \     'prefix_alias': [],
+      \     'body': [
+      \       'snippet'
+      \     ],
+      \   }
+      \ })
+    End
+
+  End
+
+End
+

--- a/misc/global.json
+++ b/misc/global.json
@@ -1,4 +1,10 @@
 {
+  "Test1": {
+    "prefix": ["test1"],
+    "body": [
+      "snippet"
+    ]
+  },
   "Complex example": {
     "prefix": ["complex-example"],
     "body": [

--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -59,17 +59,13 @@ endif
 inoremap <silent> <Plug>(vsnip-expand-or-jump) <Esc>:<C-u>call <SID>expand_or_jump()<CR>
 snoremap <silent> <Plug>(vsnip-expand-or-jump) <Esc>:<C-u>call <SID>expand_or_jump()<CR>
 function! s:expand_or_jump()
-  let l:ctx = {}
-  function! l:ctx.callback() abort
-    let l:context = vsnip#get_context()
-    let l:session = vsnip#get_session()
-    if !empty(l:context)
-      call vsnip#expand()
-    elseif !empty(l:session) && l:session.jumpable(1)
-      call l:session.jump(1)
-    endif
-  endfunction
-  return s:map({ -> l:ctx.callback() })
+  let l:context = vsnip#get_context()
+  let l:session = vsnip#get_session()
+  if !empty(l:context)
+    call vsnip#expand()
+  elseif !empty(l:session) && l:session.jumpable(1)
+    call l:session.jump(1)
+  endif
 endfunction
 
 "
@@ -78,11 +74,7 @@ endfunction
 inoremap <silent> <Plug>(vsnip-expand) <Esc>:<C-u>call <SID>expand()<CR>
 snoremap <silent> <Plug>(vsnip-expand) <C-g><Esc>:<C-u>call <SID>expand()<CR>
 function! s:expand() abort
-  let l:ctx = {}
-  function! l:ctx.callback() abort
-    call vsnip#expand()
-  endfunction
-  return s:map({ -> l:ctx.callback() })
+  call vsnip#expand()
 endfunction
 
 "
@@ -94,15 +86,10 @@ snoremap <silent> <Plug>(vsnip-jump-next) <Esc>:<C-u>call <SID>jump(1)<CR>
 inoremap <silent> <Plug>(vsnip-jump-prev) <Esc>:<C-u>call <SID>jump(-1)<CR>
 snoremap <silent> <Plug>(vsnip-jump-prev) <Esc>:<C-u>call <SID>jump(-1)<CR>
 function! s:jump(direction) abort
-  let l:ctx = {}
-  let l:ctx.direction = a:direction
-  function! l:ctx.callback() abort
-    let l:session = vsnip#get_session()
-    if !empty(l:session) && l:session.jumpable(self.direction)
-      call l:session.jump(self.direction)
-    endif
-  endfunction
-  return s:map({ -> l:ctx.callback() })
+  let l:session = vsnip#get_session()
+  if !empty(l:session) && l:session.jumpable(a:direction)
+    call l:session.jump(a:direction)
+  endif
 endfunction
 
 "
@@ -152,23 +139,6 @@ function! s:vsnip_set_text(type, copy) abort
 endfunction
 function! s:virtualedit_in_normal() abort
   return &virtualedit =~? '\<all\>'
-endfunction
-
-"
-" map
-"
-function! s:map(fn) abort
-  let l:virtualedit = &virtualedit
-  let &virtualedit = 'onemore'
-
-  try
-    normal! l
-    call a:fn()
-  catch /.*/
-    echomsg string({ 'exception': v:exception, 'throwpoint': v:throwpoint })
-  endtry
-
-  let &virtualedit = l:virtualedit
 endfunction
 
 "


### PR DESCRIPTION
Currently, vsnip uses `s:map` utility to normalize insert-mode offset/virtual-mode offset, etc.

But I have noticed it was the wrong decision.
Because vsnip's suggested key mapping is `imap <expr><C-l> vsnip#expandable() ? '<Plug>(vsnip-expand)' : '<C-l>'`.

The `vsnip#expandable` call is not using `s:map`.

So I thought should be better to add the ability of mode aware `vsnip#get_context`.