### PR TITLE
[Breaking change] Add `g:vsnip_filetypes` variable

### DIFF
--- a/.themisrc
+++ b/.themisrc
@@ -11,6 +11,9 @@ endif
 
 let g:vsnip_test_mode = v:true
 let g:vsnip_snippet_dir = fnamemodify(expand('<sfile>'), ':h') . '/misc'
+let &runtimepath .= ',' . g:vsnip_snippet_dir . '/vscode'
+let g:vsnip_filetypes = {}
+let g:vsnip_filetypes.javascriptreact = ['javascript']
 
 imap <expr> <C-j>   vsnip#expandable()  ? '<Plug>(vsnip-expand)'         : '<C-j>'
 smap <expr> <C-j>   vsnip#expandable()  ? '<Plug>(vsnip-expand)'         : '<C-j>'

--- a/autoload/vsnip.vim
+++ b/autoload/vsnip.vim
@@ -107,7 +107,7 @@ function! vsnip#get_context() abort
     return {}
   endif
 
-  for l:source in vsnip#source#find(&filetype)
+  for l:source in vsnip#source#find(bufnr('%'))
     for l:snippet in l:source
       for l:prefix in (l:snippet.prefix + l:snippet.prefix_alias)
         let l:prefix_len = strchars(l:prefix)

--- a/autoload/vsnip/source.vim
+++ b/autoload/vsnip/source.vim
@@ -9,11 +9,19 @@ endfunction
 "
 " vsnip#source#find.
 "
-function! vsnip#source#find(filetype) abort
+function! vsnip#source#find(bufnr) abort
   let l:sources = []
-  let l:sources += vsnip#source#user_snippet#find(a:filetype)
-  let l:sources += vsnip#source#vscode#find(a:filetype)
+  let l:sources += vsnip#source#user_snippet#find(a:bufnr)
+  let l:sources += vsnip#source#vscode#find(a:bufnr)
   return l:sources
+endfunction
+
+"
+" vsnip#source#filetypes
+"
+function! vsnip#source#filetypes(bufnr) abort
+  let l:filetype = getbufvar(a:bufnr, '&filetype', '')
+  return [l:filetype] + get(g:vsnip_filetypes, l:filetype, []) + ['global']
 endfunction
 
 "

--- a/autoload/vsnip/source/user_snippet.vim
+++ b/autoload/vsnip/source/user_snippet.vim
@@ -3,9 +3,9 @@ let s:cache = {}
 "
 " vsnip#source#user_snippet#find.
 "
-function! vsnip#source#user_snippet#find(filetype) abort
+function! vsnip#source#user_snippet#find(bufnr) abort
   let l:sources = []
-  for l:path in s:get_source_paths(a:filetype)
+  for l:path in s:get_source_paths(a:bufnr)
     if !has_key(s:cache, l:path)
       let s:cache[l:path] = vsnip#source#create(l:path)
     endif
@@ -26,11 +26,13 @@ endfunction
 "
 " get_source_paths.
 "
-function! s:get_source_paths(filetype) abort
+function! s:get_source_paths(bufnr) abort
+  let l:filetypes = vsnip#source#filetypes(a:bufnr)
+
   let l:paths = []
   for l:dir in [g:vsnip_snippet_dir] + g:vsnip_snippet_dirs
-    for l:name in split(a:filetype, '\.') + ['global']
-      let l:path = resolve(expand(printf('%s/%s.json', l:dir, l:name)))
+    for l:filetype in l:filetypes
+      let l:path = resolve(expand(printf('%s/%s.json', l:dir, l:filetype)))
       if has_key(s:cache, l:path) || filereadable(l:path)
         call add(l:paths, l:path)
       endif

--- a/autoload/vsnip/source/vscode.vim
+++ b/autoload/vsnip/source/vscode.vim
@@ -19,8 +19,8 @@ endfunction
 "
 " vsnip#source#vscode#find.
 "
-function! vsnip#source#vscode#find(filetype) abort
-  return s:find(s:get_language(a:filetype))
+function! vsnip#source#vscode#find(bufnr) abort
+  return s:find(s:get_language(getbufvar(a:bufnr, '&filetype', '')))
 endfunction
 
 "
@@ -79,7 +79,7 @@ function! s:find(language) abort
 endfunction
 
 "
-" get_language_id.
+" get_language.
 "
 function! s:get_language(filetype) abort
   return get({

--- a/doc/vsnip.txt
+++ b/doc/vsnip.txt
@@ -69,6 +69,16 @@ VARIABLE                                                      *vsnip-variable*
 
 
 >
+  let g:vsnip_filetypes = {}
+<
+    Specify extended filetypes.
+    For example, you can extend `javascript` filetype with `javascriptreact` filetype.
+>
+      let g:vsnip_filetypes = {}
+      let g:vsnip_filetypes.javascriptreact = ['javascript']
+<
+
+>
   let g:vsnip_sync_delay = 0
 <
     Specify delay time to sync same tabstop placeholder.

--- a/misc/javascript.json
+++ b/misc/javascript.json
@@ -1,0 +1,10 @@
+{
+  "func": {
+    "prefix": ["func"],
+    "body": [
+      "function ${1:name}() {",
+      "\t$0",
+      "}"
+    ]
+  }
+}

--- a/misc/vscode/package.json
+++ b/misc/vscode/package.json
@@ -1,0 +1,10 @@
+{
+  "contributes": {
+    "snippets": [
+      {
+        "path": "./vim.json",
+        "language": "vim"
+      }
+    ]
+  }
+}

--- a/misc/vscode/vim.json
+++ b/misc/vscode/vim.json
@@ -1,0 +1,10 @@
+{
+  "func": {
+    "prefix": "func",
+    "body": [
+      "function! ${1:name}() abort",
+      "\t$0",
+      "endfunction"
+    ]
+  }
+}

--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -12,6 +12,10 @@ let g:vsnip_snippet_dirs = get(g:, 'vsnip_snippet_dirs', [])
 let g:vsnip_sync_delay = get(g:, 'vsnip_sync_delay', 0)
 let g:vsnip_choice_delay = get(g:, 'vsnip_choice_delay', 500)
 let g:vsnip_namespace = get(g:, 'vsnip_namespace', '')
+let g:vsnip_filetypes = get(g:, 'vsnip_filetypes', {})
+let g:vsnip_filetypes.typescriptreact = get(g:vsnip_filetypes, 'typescriptreact', ['typescript'])
+let g:vsnip_filetypes.javascriptreact = get(g:vsnip_filetypes, 'javascriptreact', ['javascript'])
+let g:vsnip_filetypes.vimspec = get(g:vsnip_filetypes, 'vimspec', ['vim'])
 
 "
 " command
@@ -21,7 +25,7 @@ command! -bang VsnipOpenEdit call s:open_command(<bang>0, 'edit')
 command! -bang VsnipOpenVsplit call s:open_command(<bang>0, 'vsplit')
 command! -bang VsnipOpenSplit call s:open_command(<bang>0, 'split')
 function! s:open_command(bang, cmd)
-  let l:candidates = split(&filetype, '\.') + ['global']
+  let l:candidates = vsnip#source#filetypes(bufnr('%')) + ['global']
   if a:bang
     let l:idx = 1
   else

--- a/spec/autoload/vsnip/source.vimspec
+++ b/spec/autoload/vsnip/source.vimspec
@@ -1,0 +1,44 @@
+let s:expect = themis#helper('expect')
+
+Describe vsnip#source
+
+  Describe #find
+
+    It should load snippet for extended filetypes
+      enew!
+      set filetype=javascriptreact
+      let l:snippets = vsnip#source#find(bufnr('%'))
+      call s:expect(l:snippets[0][0]).to_equal({
+      \   'label': 'func',
+      \   'description': '',
+      \   'prefix': ['func'],
+      \   'prefix_alias': [],
+      \   'body': [
+      \     'function ${1:name}() {',
+      \     "\t$0",
+      \     '}'
+      \   ]
+      \ })
+    End
+
+    It should load snippet from vscode extension
+      enew!
+      set filetype=vim
+      let l:snippets = vsnip#source#find(bufnr('%'))
+      call s:expect(l:snippets[1][0]).to_equal({
+      \   'label': 'func',
+      \   'description': '',
+      \   'prefix': ['func'],
+      \   'prefix_alias': [],
+      \   'body': [
+      \     'function! ${1:name}() abort',
+      \     "\t$0",
+      \     'endfunction'
+      \   ]
+      \ })
+    End
+
+  End
+
+End
+


### PR DESCRIPTION
Implement https://github.com/hrsh7th/vim-vsnip/issues/81

This PR has breaking change.
The `javascript.tsx` filetype now on interpretated as `['javascript.tsx']` instead of `['javascript`, 'tsx']`.
