### PR TITLE
fix: reindent lines set at snippet expansion

### DIFF
--- a/autoload/vital/_vsnip/VS/LSP/TextEdit.vim
+++ b/autoload/vital/_vsnip/VS/LSP/TextEdit.vim
@@ -111,6 +111,8 @@ function! s:_apply(bufnr, text_edit, cursor_position) abort
     endif
     let l:i += 1
   endwhile
+  exe a:text_edit.range.start.line
+  exe 'normal!' l:i . '=='
 endfunction
 
 "


### PR DESCRIPTION
Run 'normal! ==' on changed lines after snippet expansion.

Fixes #86.

Not sure if this approach can cause troubles of some sort but I dind't have problems yet. Some testing is needed.