### PR TITLE
Implement custom variable register api

### DIFF
--- a/autoload/vsnip/snippet/node/variable.vim
+++ b/autoload/vsnip/snippet/node/variable.vim
@@ -1,35 +1,6 @@
-" @see https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables
-" TODO: BLOCK_COMMENT_START, BLOCK_COMMENT_END, LINE_COMMENT
-let s:known_variables = {
-\   'TM_SELECTED_TEXT': { -> vsnip#selected_text()},
-\   'TM_CURRENT_LINE': { -> getline('.')},
-\   'TM_CURRENT_WORD': { -> ''},
-\   'TM_LINE_INDEX': { -> line('.') - 1},
-\   'TM_LINE_NUMBER': { -> line('.')},
-\   'TM_FILENAME': { -> expand('%:p:t')},
-\   'TM_FILENAME_BASE': { -> substitute(expand('%:p:t'), '^\@<!\..*$', '', '')},
-\   'TM_DIRECTORY': { -> expand('%:p:h:t')},
-\   'TM_FILEPATH': { -> expand('%:p')},
-\   'CLIPBOARD': { -> getreg(v:register)},
-\   'WORKSPACE_NAME': { -> ''},
-\   'CURRENT_YEAR': { -> strftime('%Y')},
-\   'CURRENT_YEAR_SHORT': { -> strftime('%y')},
-\   'CURRENT_MONTH': { -> strftime('%m')},
-\   'CURRENT_MONTH_NAME': { -> strftime('%B')},
-\   'CURRENT_MONTH_NAME_SHORT': { -> strftime('%b')},
-\   'CURRENT_DATE': { -> strftime('%d')},
-\   'CURRENT_DAY_NAME': { -> strftime('%A')},
-\   'CURRENT_DAY_NAME_SHORT': { -> strftime('%a')},
-\   'CURRENT_HOUR': { -> strftime('%H')},
-\   'CURRENT_MINUTE': { -> strftime('%M')},
-\   'CURRENT_SECOND': { -> strftime('%S')},
-\   'CURRENT_SECONDS_UNIX': { -> localtime()},
-\   'BLOCK_COMMENT_START': { -> '/**'},
-\   'BLOCK_COMMENT_END': { -> '*/'},
-\   'LINE_COMMENT': { -> '//'},
-\ }
-
-
+"
+" vsnip#snippet#node#variable#import
+"
 function! vsnip#snippet#node#variable#import() abort
   return s:Variable
 endfunction
@@ -43,7 +14,9 @@ function! s:Variable.new(ast) abort
   return extend(deepcopy(s:Variable), {
   \   'type': 'variable',
   \   'name': a:ast.name,
-  \   'unknown': !has_key(s:known_variables, a:ast.name),
+  \   'value': '',
+  \   'resolved': v:false,
+  \   'resolver': vsnip#variable#get(a:ast.name),
   \   'children': vsnip#snippet#node#create_from_ast(get(a:ast, 'children', [])),
   \ })
 endfunction
@@ -52,21 +25,38 @@ endfunction
 " text.
 "
 function! s:Variable.text() abort
-  return self.resolve()
+  if empty(self.resolver)
+    return join(map(copy(self.children), { k, v -> v.text() }), '')
+  endif
+  return self.value
+endfunction
+
+"
+" should_resolve.
+"
+function! s:Variable.should_resolve() abort
+  return !empty(self.resolver) && !(self.resolver.once && self.resolved)
+endfunction
+
+"
+" update.
+"
+function! s:Variable.update(value) abort
+  let self.value = a:value
+  let self.resolved = v:true
 endfunction
 
 "
 " resolve.
 "
-function! s:Variable.resolve() abort
-  if has_key(s:known_variables, self.name)
-    let l:resolved = s:known_variables[self.name]()
-    if !empty(l:resolved)
-      return l:resolved
+function! s:Variable.resolve(context) abort
+  if !empty(self.resolver)
+    let l:value = self.resolver.func(a:context)
+    if !empty(l:value)
+      return l:value
     endif
   endif
-
-  return join(map(copy(self.children), { k, v -> v.text() }), '')
+  return v:null
 endfunction
 
 "
@@ -75,8 +65,9 @@ endfunction
 function! s:Variable.to_string() abort
   return printf('%s(name=%s, unknown=%s, resolved=%s)',
   \   self.type,
-  \   self.unknown ? 'true' : 'false',
-  \   self.resolve()
+  \   self.name,
+  \   empty(self.resolver) ? 'true' : 'false',
+  \   self.value
   \ )
 endfunction
 

--- a/autoload/vsnip/variable.vim
+++ b/autoload/vsnip/variable.vim
@@ -1,0 +1,162 @@
+let s:variables = {}
+
+"
+" vsnip#variable#register
+"
+function! vsnip#variable#register(name, func, ...) abort
+  let l:option = get(a:000, 0, {})
+  let s:variables[a:name] = {
+  \   'func': a:func,
+  \   'once': get(l:option, 'once', v:false)
+  \ }
+endfunction
+
+"
+" vsnip#variable#get
+"
+function! vsnip#variable#get(name) abort
+  return get(s:variables, a:name, v:null)
+endfunction
+
+"
+" Register built-in variables.
+"
+" @see https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables
+"
+
+function! s:TM_SELECTED_TEXT(context) abort
+  return vsnip#selected_text()
+endfunction
+call vsnip#variable#register('TM_SELECTED_TEXT', function('s:TM_SELECTED_TEXT'))
+
+function! s:TM_CURRENT_LINE(context) abort
+  return getline('.')
+endfunction
+call vsnip#variable#register('TM_CURRENT_LINE', function('s:TM_CURRENT_LINE'))
+
+function! s:TM_CURRENT_WORD(context) abort
+  return '' " TODO
+endfunction
+call vsnip#variable#register('TM_CURRENT_WORD', function('s:TM_CURRENT_WORD'))
+
+function! s:TM_LINE_INDEX(context) abort
+  return line('.') - 1
+endfunction
+call vsnip#variable#register('TM_LINE_INDEX', function('s:TM_LINE_INDEX'))
+
+function! s:TM_LINE_NUMBER(context) abort
+  return line('.')
+endfunction
+call vsnip#variable#register('TM_LINE_NUMBER', function('s:TM_LINE_NUMBER'))
+
+function! s:TM_FILENAME(context) abort
+  return expand('%:p:t')
+endfunction
+call vsnip#variable#register('TM_FILENAME', function('s:TM_FILENAME'))
+
+function! s:TM_FILENAME_BASE(context) abort
+  return substitute(expand('%:p:t'), '^\@<!\..*$', '', '')
+endfunction
+call vsnip#variable#register('TM_FILENAME_BASE', function('s:TM_FILENAME_BASE'))
+
+function! s:TM_DIRECTORY(context) abort
+  return expand('%:p:h:t')
+endfunction
+call vsnip#variable#register('TM_DIRECTORY', function('s:TM_DIRECTORY'))
+
+function! s:TM_FILEPATH(context) abort
+  return expand('%:p')
+endfunction
+call vsnip#variable#register('TM_FILEPATH', function('s:TM_FILEPATH'))
+
+function! s:CLIPBOARD(context) abort
+  return getreg(v:register)
+endfunction
+call vsnip#variable#register('CLIPBOARD', function('s:CLIPBOARD'))
+
+function! s:WORKSPACE_NAME(context) abort
+  return ''
+endfunction
+call vsnip#variable#register('WORKSPACE_NAME', function('s:WORKSPACE_NAME'))
+
+function! s:CURRENT_YEAR(context) abort
+  return strftime('%Y')
+endfunction
+call vsnip#variable#register('CURRENT_YEAR', function('s:CURRENT_YEAR'))
+
+function! s:CURRENT_YEAR_SHORT(context) abort
+  return strftime('%y')
+endfunction
+call vsnip#variable#register('CURRENT_YEAR_SHORT', function('s:CURRENT_YEAR_SHORT'))
+
+function! s:CURRENT_MONTH(context) abort
+  return strftime('%m')
+endfunction
+call vsnip#variable#register('CURRENT_MONTH', function('s:CURRENT_MONTH'))
+
+function! s:CURRENT_MONTH_NAME(context) abort
+  return strftime('%B')
+endfunction
+call vsnip#variable#register('CURRENT_MONTH_NAME', function('s:CURRENT_MONTH_NAME'))
+
+function! s:CURRENT_MONTH_NAME_SHORT(context) abort
+  return strftime('%b')
+endfunction
+call vsnip#variable#register('CURRENT_MONTH_NAME_SHORT', function('s:CURRENT_MONTH_NAME_SHORT'))
+
+function! s:CURRENT_DATE(context) abort
+  return strftime('%d')
+endfunction
+call vsnip#variable#register('CURRENT_DATE', function('s:CURRENT_DATE'))
+
+function! s:CURRENT_DAY_NAME(context) abort
+  return strftime('%A')
+endfunction
+call vsnip#variable#register('CURRENT_DAY_NAME', function('s:CURRENT_DAY_NAME'))
+
+function! s:CURRENT_DAY_NAME_SHORT(context) abort
+  return strftime('%a')
+endfunction
+call vsnip#variable#register('CURRENT_DAY_NAME_SHORT', function('s:CURRENT_DAY_NAME_SHORT'))
+
+function! s:CURRENT_HOUR(context) abort
+  return strftime('%H')
+endfunction
+call vsnip#variable#register('CURRENT_HOUR', function('s:CURRENT_HOUR'))
+
+function! s:CURRENT_MINUTE(context) abort
+  return strftime('%M')
+endfunction
+call vsnip#variable#register('CURRENT_MINUTE', function('s:CURRENT_MINUTE'))
+
+function! s:CURRENT_SECOND(context) abort
+  return strftime('%S')
+endfunction
+call vsnip#variable#register('CURRENT_SECOND', function('s:CURRENT_SECOND'))
+
+function! s:CURRENT_SECONDS_UNIX(context) abort
+  return localtime()
+endfunction
+call vsnip#variable#register('CURRENT_SECONDS_UNIX', function('s:CURRENT_SECONDS_UNIX'))
+
+function! s:BLOCK_COMMENT_START(context) abort
+  return '/**' " TODO
+endfunction
+call vsnip#variable#register('BLOCK_COMMENT_START', function('s:BLOCK_COMMENT_START'))
+
+function! s:BLOCK_COMMENT_END(context) abort
+  return '*/' " TODO
+endfunction
+call vsnip#variable#register('BLOCK_COMMENT_END', function('s:BLOCK_COMMENT_END'))
+
+function! s:LINE_COMMENT(context) abort
+  return '//' " TODO
+endfunction
+call vsnip#variable#register('LINE_COMMENT', function('s:LINE_COMMENT'))
+
+function! s:EVAL_VIM(context) abort
+  let l:script = join(map(copy(a:context.node.children), 'v:val.text()'), '')
+  return eval(l:script)
+endfunction
+call vsnip#variable#register('EVAL_VIM', function('s:EVAL_VIM'))
+


### PR DESCRIPTION
Fixes #93, #86

#### Overview
This PR aims to register a custom variable resolver that can realize some of the interpolation related functionality.
For example, we can register the below variable for vim interpolation.

```viml
function! s:EVAL_VIM(context) abort
  let l:script = join(map(copy(a:context.node.children), 'v:val.text()'), '')
  return eval(l:script)
endfunction
call vsnip#variable#register('EVAL_VIM', function('s:EVAL_VIM'))
```

```json
  "changedtick": {
    "prefix": "var",
    "body": [
      "${EVAL_VIM:getbufvar('%', 'changedtick')}"
    ]
  },
```

Currently, custom variable context is the below structure.

```viml
let a:context = {
\   'node': s:Variable, " the resolving variable node
\   'before': string, " the forward snippet text for the resolving variable before sync
\   'after': string, " the backward snippet text for the resolving variable before sync
\ }
```

#### TODO
- [ ] Pass $TM_SELECTED_TEXT test case
- [ ] Docs
- [ ] Add some tests
- [ ] Fix potential bug of variable children