### PR TITLE
Improve $TM_SELECTED_TEXT/$CLIPBOARD indentation

### DIFF
--- a/autoload/vsnip/indent.vim
+++ b/autoload/vsnip/indent.vim
@@ -20,7 +20,7 @@ function! vsnip#indent#adjust_snippet_body(line, text) abort
   let l:base_indent = vsnip#indent#get_base_indent(a:line)
   let l:text = a:text
   if l:one_indent !=# "\t"
-    while match(l:text, "\\%(^\\|\n\\)\\s*\\zs\\t") isnot# -1
+    while match(l:text, "\\%(^\\|\n\\)\\s*\\zs\\t") != -1
       let l:text = substitute(l:text, "\\%(^\\|\n\\)\\s*\\zs\\t", l:one_indent, 'g') " convert \t as one indent
     endwhile
   endif
@@ -33,7 +33,7 @@ endfunction
 " vsnip#indent#trim_base_indent
 "
 function! vsnip#indent#trim_base_indent(text) abort
-  let l:is_char_wise = match(a:text, "\n$") is# -1
+  let l:is_char_wise = match(a:text, "\n$") == -1
   let l:text = substitute(a:text, "\n$", '', 'g')
 
   let l:is_first_line = v:true

--- a/autoload/vsnip/indent.vim
+++ b/autoload/vsnip/indent.vim
@@ -29,10 +29,15 @@ endfunction
 " vsnip#indent#trim_base_indent
 "
 function! vsnip#indent#trim_base_indent(text) abort
+  let l:is_first_line = v:true
   let l:base_indent = ''
   for l:line in split(a:text, "\n", v:true)
+    if l:is_first_line
+      let l:is_first_line = v:false
+      continue
+    endif
     let l:indent = matchstr(l:line, '^\s*')
-    if l:base_indent ==# '' || l:indent !=# '' && strlen(l:indent) < strlen(l:base_indent)
+    if l:base_indent ==# '' || strlen(l:indent) < strlen(l:base_indent)
       let l:base_indent = l:indent
     endif
   endfor

--- a/autoload/vsnip/indent.vim
+++ b/autoload/vsnip/indent.vim
@@ -1,0 +1,41 @@
+"
+" vsnip#indent#get_one_indent
+"
+function! vsnip#indent#get_one_indent() abort
+  return !&expandtab ? "\t" : repeat(' ', &shiftwidth ? &shiftwidth : &tabstop)
+endfunction
+
+"
+" vsnip#indent#get_base_indent
+"
+function! vsnip#indent#get_base_indent(text) abort
+  return matchstr(a:text, '^\s*')
+endfunction
+
+"
+" vsnip#indent#adjust_snippet_body
+"
+function! vsnip#indent#adjust_snippet_body(line, text) abort
+  let l:one_indent = vsnip#indent#get_one_indent()
+  let l:base_indent = vsnip#indent#get_base_indent(a:line)
+  let l:text = a:text
+  let l:text = substitute(l:text, "\t", l:one_indent, 'g') " convert \t as one indent
+  let l:text = substitute(l:text, "\n\\zs", l:base_indent, 'g') " add base_indent for all lines
+  let l:text = substitute(l:text, "\n\\s*\\ze\\(\n\\|$\\)", "\n", 'g') " remove empty line's indent
+  return l:text
+endfunction
+
+"
+" vsnip#indent#trim_base_indent
+"
+function! vsnip#indent#trim_base_indent(text) abort
+  let l:base_indent = ''
+  for l:line in split(a:text, "\n", v:true)
+    let l:indent = matchstr(l:line, '^\s*')
+    if l:base_indent ==# '' || l:indent !=# '' && strlen(l:indent) < strlen(l:base_indent)
+      let l:base_indent = l:indent
+    endif
+  endfor
+  return substitute(a:text, "\\%(^\\|\n\\)\\zs\\V" . l:base_indent, '', 'g')
+endfunction
+

--- a/autoload/vsnip/indent.vim
+++ b/autoload/vsnip/indent.vim
@@ -19,7 +19,11 @@ function! vsnip#indent#adjust_snippet_body(line, text) abort
   let l:one_indent = vsnip#indent#get_one_indent()
   let l:base_indent = vsnip#indent#get_base_indent(a:line)
   let l:text = a:text
-  let l:text = substitute(l:text, "\t", l:one_indent, 'g') " convert \t as one indent
+  if l:one_indent !=# "\t"
+    while match(l:text, "\\%(^\\|\n\\)\\s*\\zs\\t") isnot# -1
+      let l:text = substitute(l:text, "\\%(^\\|\n\\)\\s*\\zs\\t", l:one_indent, 'g') " convert \t as one indent
+    endwhile
+  endif
   let l:text = substitute(l:text, "\n\\zs", l:base_indent, 'g') " add base_indent for all lines
   let l:text = substitute(l:text, "\n\\s*\\ze\\(\n\\|$\\)", "\n", 'g') " remove empty line's indent
   return l:text

--- a/autoload/vsnip/indent.vim
+++ b/autoload/vsnip/indent.vim
@@ -29,18 +29,29 @@ endfunction
 " vsnip#indent#trim_base_indent
 "
 function! vsnip#indent#trim_base_indent(text) abort
+  let l:is_char_wise = match(a:text, "\n$") is# -1
+  let l:text = substitute(a:text, "\n$", '', 'g')
+
   let l:is_first_line = v:true
   let l:base_indent = ''
-  for l:line in split(a:text, "\n", v:true)
-    if l:is_first_line
+  for l:line in split(l:text, "\n", v:true)
+    " Ignore the first line when the text created as char-wise.
+    if l:is_char_wise && l:is_first_line
       let l:is_first_line = v:false
       continue
     endif
+
+    " Ignore empty line.
+    if l:line ==# ''
+      continue
+    endif
+
+    " Detect most minimum base indent.
     let l:indent = matchstr(l:line, '^\s*')
     if l:base_indent ==# '' || strlen(l:indent) < strlen(l:base_indent)
       let l:base_indent = l:indent
     endif
   endfor
-  return substitute(a:text, "\\%(^\\|\n\\)\\zs\\V" . l:base_indent, '', 'g')
+  return substitute(l:text, "\\%(^\\|\n\\)\\zs\\V" . l:base_indent, '', 'g')
 endfunction
 

--- a/autoload/vsnip/session.vim
+++ b/autoload/vsnip/session.vim
@@ -21,7 +21,7 @@ function! s:Session.new(bufnr, position, text) abort
   \   'buffer': getbufline(a:bufnr, '^', '$'),
   \   'timer_id': -1,
   \   'changedtick': getbufvar(a:bufnr, 'changedtick', 0),
-  \   'snippet': s:Snippet.new(a:position, self.indent(a:text)),
+  \   'snippet': s:Snippet.new(a:position, vsnip#indent#adjust_snippet_body(getline('.'), a:text)),
   \   'tabstop': -1,
   \   'changenr': changenr(),
   \   'changenrs': {},
@@ -265,18 +265,5 @@ function! s:Session.store(changenr) abort
   \   'tabstop': self.tabstop,
   \   'snippet': deepcopy(self.snippet)
   \ }
-endfunction
-
-"
-" indent.
-"
-function! s:Session.indent(text) abort
-  let l:indent = !&expandtab ? "\t" : repeat(' ', &shiftwidth ? &shiftwidth : &tabstop)
-  let l:level = matchstr(getline('.'), '^\s*')
-  let l:text = a:text
-  let l:text = substitute(l:text, "\t", l:indent, 'g')
-  let l:text = substitute(l:text, "\n\\zs", l:level, 'g')
-  let l:text = substitute(l:text, "\n\\s*\\ze\\(\n\\|$\\)", "\n", 'g')
-  return l:text
 endfunction
 

--- a/autoload/vsnip/snippet.vim
+++ b/autoload/vsnip/snippet.vim
@@ -34,6 +34,7 @@ function s:Snippet.init() abort
   let l:fn.group = {}
   let l:fn.variable_placeholder = {}
   let l:fn.has_final_tabstop = v:false
+  let l:fn.prev_node = v:null
   function! l:fn.traverse(range, node, parent, depth) abort
     if a:node.type ==# 'placeholder'
       " Mark as follower placeholder.
@@ -66,11 +67,13 @@ function s:Snippet.init() abort
           let a:node.children = [vsnip#snippet#node#create_text(self.group[a:node.id].text())]
         endif
       else
+        let l:resolved = a:node.resolve({ 'prev_node': self.prev_node })
         let l:index = index(a:parent.children, a:node)
         call remove(a:parent.children, l:index)
-        call insert(a:parent.children, vsnip#snippet#node#create_text(a:node.text()), l:index)
+        call insert(a:parent.children, vsnip#snippet#node#create_text(l:resolved), l:index)
       endif
     endif
+    let self.prev_node = a:node
   endfunction
   call self.traverse(self, self.children, l:fn.traverse, 0, 0)
 

--- a/autoload/vsnip/snippet.vim
+++ b/autoload/vsnip/snippet.vim
@@ -28,6 +28,8 @@ endfunction
 "
 " init.
 "
+" NOTE: Must not use the node range in this method.
+"
 function s:Snippet.init() abort
   let l:fn = {}
   let l:fn.self = self
@@ -67,10 +69,11 @@ function s:Snippet.init() abort
           let a:node.children = [vsnip#snippet#node#create_text(self.group[a:node.id].text())]
         endif
       else
-        let l:resolved = a:node.resolve({ 'prev_node': self.prev_node })
+        let l:text = a:node.resolve({ 'prev_node': self.prev_node })
+        let l:text = l:text is# v:null ? a:node.text() : l:text
         let l:index = index(a:parent.children, a:node)
         call remove(a:parent.children, l:index)
-        call insert(a:parent.children, vsnip#snippet#node#create_text(l:resolved), l:index)
+        call insert(a:parent.children, vsnip#snippet#node#create_text(l:text), l:index)
       endif
     endif
     let self.prev_node = a:node

--- a/autoload/vsnip/snippet/node/variable.vim
+++ b/autoload/vsnip/snippet/node/variable.vim
@@ -29,16 +29,21 @@ endfunction
 " text.
 "
 function! s:Variable.text() abort
-  return self.resolve()
+  return ''
 endfunction
 
 "
 " resolve.
 "
-function! s:Variable.resolve() abort
+function! s:Variable.resolve(context) abort
   if !self.unknown
     let l:resolved = self.resolver.func({ 'node': self })
     if l:resolved isnot v:null
+      " Fix indent when one variable returns multiple lines
+      if !empty(get(a:context, 'prev_node', v:null))
+        let l:base_indent = vsnip#indent#get_base_indent(split(a:context.prev_node.text(), "\n", v:true)[-1])
+        let l:resolved = substitute(l:resolved, "\n\\zs", l:base_indent, 'g') " add base_indent for next all lines
+      endif
       return l:resolved
     endif
   endif
@@ -51,8 +56,9 @@ endfunction
 function! s:Variable.to_string() abort
   return printf('%s(name=%s, unknown=%s, resolved=%s)',
   \   self.type,
+  \   self.name,
   \   self.unknown ? 'true' : 'false',
-  \   self.resolve()
+  \   self.resolve({})
   \ )
 endfunction
 

--- a/autoload/vsnip/snippet/node/variable.vim
+++ b/autoload/vsnip/snippet/node/variable.vim
@@ -29,7 +29,7 @@ endfunction
 " text.
 "
 function! s:Variable.text() abort
-  return ''
+  return join(map(copy(self.children), { k, v -> v.text() }), '')
 endfunction
 
 "
@@ -47,18 +47,18 @@ function! s:Variable.resolve(context) abort
       return l:resolved
     endif
   endif
-  return join(map(copy(self.children), { k, v -> v.text() }), '')
+  return v:null
 endfunction
 
 "
 " to_string
 "
 function! s:Variable.to_string() abort
-  return printf('%s(name=%s, unknown=%s, resolved=%s)',
+  return printf('%s(name=%s, unknown=%s, text=%s)',
   \   self.type,
   \   self.name,
   \   self.unknown ? 'true' : 'false',
-  \   self.resolve({})
+  \   self.text()
   \ )
 endfunction
 

--- a/autoload/vsnip/variable.vim
+++ b/autoload/vsnip/variable.vim
@@ -74,7 +74,11 @@ endfunction
 call vsnip#variable#register('TM_FILEPATH', function('s:TM_FILEPATH'))
 
 function! s:CLIPBOARD(context) abort
-  return getreg(v:register)
+  let l:clipboard = getreg(v:register)
+  if empty(l:clipboard)
+    return v:null
+  endif
+  return vsnip#indent#trim_base_indent(l:clipboard)
 endfunction
 call vsnip#variable#register('CLIPBOARD', function('s:CLIPBOARD'))
 

--- a/autoload/vsnip/variable.vim
+++ b/autoload/vsnip/variable.vim
@@ -29,7 +29,7 @@ function! s:TM_SELECTED_TEXT(context) abort
   if empty(l:selected_text)
     return v:null
   endif
-  return l:selected_text " TODO: Fix indentation
+  return vsnip#indent#trim_base_indent(l:selected_text)
 endfunction
 call vsnip#variable#register('TM_SELECTED_TEXT', function('s:TM_SELECTED_TEXT'))
 

--- a/misc/integration.json
+++ b/misc/integration.json
@@ -88,6 +88,15 @@
       "${VIM:\\$USER}"
     ]
   },
+  "realworld3": {
+    "description": "realworld3",
+    "prefix": ["realworld3"],
+    "body": [
+      "<div>",
+      "\t$TM_SELECTED_TEXT",
+      "</div>"
+    ]
+  },
   "issue82": {
     "description": "issue82",
     "prefix": ["'"],

--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -138,7 +138,7 @@ function! s:vsnip_set_text(type, copy) abort
     return
   endif
   execute 'normal! '.select.a:copy
-  call vsnip#selected_text(substitute(@v, '\n$', '', ''))
+  call vsnip#selected_text(@v)
   let @v = reg_v
 endfunction
 function! s:virtualedit_in_normal() abort

--- a/spec/autoload/vsnip/indent.vimspec
+++ b/spec/autoload/vsnip/indent.vimspec
@@ -1,0 +1,128 @@
+let s:expect = themis#helper('expect')
+
+Describe vsnip#indent
+
+  After each
+    set expandtab shiftwidth=2
+  End
+
+  Describe #get_one_indent
+
+    It should return one indent
+      enew!
+      for l:execute in [
+      \   'set expandtab shiftwidth=4   tabstop=2',
+      \   'set expandtab shiftwidth=2   tabstop=4',
+      \   'set expandtab shiftwidth=0   tabstop=2',
+      \   'set noexpandtab shiftwidth=4 tabstop=4',
+      \ ]
+        execute l:execute
+        %delete _
+        call feedkeys("i\<Tab>", 'nx') 
+        call s:expect(vsnip#indent#get_one_indent()).to_equal(getline(1))
+      endfor
+
+    End
+
+  End
+
+  Describe #get_base_indent
+
+    It should return base indent
+      enew!
+
+      call setline(1, ['foo'])
+      call s:expect(vsnip#indent#get_base_indent(getline(1))).to_equal('')
+
+      call setline(1, ['  foo'])
+      call s:expect(vsnip#indent#get_base_indent(getline(1))).to_equal('  ')
+
+      call setline(1, ["\tfoo"])
+      call s:expect(vsnip#indent#get_base_indent(getline(1))).to_equal("\t")
+    End
+
+  End
+
+  Describe #adjust_snippet_body
+
+    It should return adjusted snippet body for expandtab
+      set expandtab shiftwidth=2
+      call s:expect(vsnip#indent#adjust_snippet_body('  foo', join([
+      \   "class $1 {",
+      \   "\tpublic constructor() {",
+      \   "\t\t$0",
+      \   "\t}",
+      \   "}"
+      \ ], "\n"))).to_equal(join([
+      \   "class $1 {",
+      \   "    public constructor() {",
+      \   "      $0",
+      \   "    }",
+      \   "  }"
+      \ ], "\n"))
+    End
+
+    It should return adjusted snippet body for noexpandtab
+      set noexpandtab shiftwidth=2
+      call s:expect(vsnip#indent#adjust_snippet_body("\tfoo", join([
+      \   "class $1 {",
+      \   "\tpublic constructor() {",
+      \   "\t\t$0",
+      \   "\t}",
+      \   "}"
+      \ ], "\n"))).to_equal(join([
+      \   "class $1 {",
+      \   "\t\tpublic constructor() {",
+      \   "\t\t\t$0",
+      \   "\t\t}",
+      \   "\t}"
+      \ ], "\n"))
+    End
+
+  End
+
+  Describe #trim_base_indent
+
+    It should trim base indent when target is line-wise multiline text
+      call s:expect(vsnip#indent#trim_base_indent(join([
+      \   "  function! s:foo()",
+      \   "    return 'foo'",
+      \   "  endfunction"
+      \ ], "\n") . "\n")).to_equal(join([
+      \   "function! s:foo()",
+      \   "  return 'foo'",
+      \   "endfunction"
+      \ ], "\n"))
+    End
+
+    It should trim base indent when target is char-wise multiline text
+      call s:expect(vsnip#indent#trim_base_indent(join([
+      \   "function! s:foo()",
+      \   "    return 'foo'",
+      \   "  endfunction"
+      \ ], "\n"))).to_equal(join([
+      \   "function! s:foo()",
+      \   "  return 'foo'",
+      \   "endfunction"
+      \ ], "\n"))
+    End
+
+    It should trim base indent when target is line-wise singleline selection
+      call s:expect(vsnip#indent#trim_base_indent(join([
+      \   "  function! s:foo()",
+      \ ], "\n") . "\n")).to_equal(join([
+      \   "function! s:foo()",
+      \ ], "\n"))
+    End
+
+    It should trim base indent when target is char-wise singleline selection
+      call s:expect(vsnip#indent#trim_base_indent(join([
+      \   "  function! s:foo()",
+      \ ], "\n"))).to_equal(join([
+      \   "  function! s:foo()",
+      \ ], "\n"))
+    End
+
+  End
+
+End

--- a/spec/plugin/vsnip.vimspec
+++ b/spec/plugin/vsnip.vimspec
@@ -222,7 +222,7 @@ Describe vsnip
 
   Context realworld
 
-    It should work spec1
+    It should work spec1 (complex sequence)
       enew!
       set filetype=integration
       call setline(1, 'realworld1')
@@ -299,7 +299,7 @@ Describe vsnip
       call feedkeys(l:sequence, 'x')
     End
 
-    It should work spec2
+    It should work spec2 ($VIM variable)
       enew!
       set filetype=integration
       call setline(1, 'realworld2')
@@ -312,6 +312,48 @@ Describe vsnip
         \ ])
       endfunction
       call feedkeys("a\<C-j>\<Plug>(vsnip-assert)", 'x')
+    End
+
+    It should work spec3 ($TM_SELECTED_TEXT char-wise)
+      enew!
+      set filetype=integration
+      call setline(1, [
+      \   '  <div>',
+      \   '    <span />',
+      \   '  </div>'
+      \ ])
+      let g:vsnip_assert = {}
+      function! g:vsnip_assert.step1() abort
+        call s:expect(getbufline('%', '^', '$')).to_equal([
+        \   '  <div>',
+        \   '    <div>',
+        \   '      <span />',
+        \   '    </div>',
+        \   '  </div>'
+        \ ])
+      endfunction
+      call feedkeys("1G3|v3G7|\<Plug>(vsnip-cut-text)realworld3\<C-j>", 'x')
+    End
+
+    It should work spec4 ($TM_SELECTED_TEXT line-wise)
+      enew!
+      set filetype=integration
+      call setline(1, [
+      \   '  <div>',
+      \   '    <span />',
+      \   '  </div>'
+      \ ])
+      let g:vsnip_assert = {}
+      function! g:vsnip_assert.step1() abort
+        call s:expect(getbufline('%', '^', '$')).to_equal([
+        \   '  <div>',
+        \   '    <div>',
+        \   '      <span />',
+        \   '    </div>',
+        \   '  </div>'
+        \ ])
+      endfunction
+      call feedkeys("1GV3G\<Plug>(vsnip-cut-text)realworld3\<C-j>", 'x')
     End
 
   End


### PR DESCRIPTION
This PR aims to fix #86 

### TODO
- [x] Write tests
- [x] Write more tests

### Overview

This PR will fix $TM_SELECTED_TEXT via the two steps.

#### 1. Format $TM_SELECTED_TEXT

```jsx
function foo() {
  return (@<div>
		<span>nickname</span>
	</div>@);
}
```

If the user select text between `@` and `@`, this PR will fix text as below.

```html
<div>
    <span>nickname</span>
</div>
```


#### 2. Fix indent for snippet's `\t`

##### The example snippet
```
<$1>
\t$TM_SELECTED_TEXT
</$1>
```

When using the example snippet, this PR will fix text as below.

```
<div>
        <span>nickname</span>
    </div>
```

Currently, the variable resolver doesn't know the `before_text` (in this case, it's `<>\n\t`).
So we should provide the `before_text` for the variable resolver.
