### PR TITLE
Improve traverse

### DIFF
--- a/autoload/vsnip/snippet.vim
+++ b/autoload/vsnip/snippet.vim
@@ -120,12 +120,12 @@ function! s:Snippet.follow(current_tabstop, diff) abort
       let l:should_update = v:false
       let l:should_update = l:should_update || empty(self.context)
       let l:should_update = l:should_update || a:context.node.type ==# 'placeholder'
-      let l:should_update = l:should_update || self.context.node.type ==# 'text' && self.diff.range[0] == self.diff.range[1]
+      let l:should_update = l:should_update || self.context.depth > a:context.depth
       if l:should_update
         let self.context = a:context
       endif
       " Stop traversing when acceptable node is current tabstop.
-      return self.context.node.type ==# 'placeholder' && self.context.node.id == self.current_tabstop
+      return self.context.node.type ==# 'placeholder' && self.context.node.id == self.current_tabstop && !self.context.node.follower
     endif
   endfunction
   call self.traverse(self, l:fn.traverse)
@@ -151,11 +151,11 @@ function! s:Snippet.follow(current_tabstop, diff) abort
   endif
 
   " Convert to text node when edited node is follower node.
-  if len(l:context.parents) > 1
-    echomsg string(["map(copy(l:context.parents), 'v:val.type)')", l:context.node.type, map(copy(l:context.parents), 'v:val.type . get(v:val, "follower", v:false)')])
-    for l:i in range(1, len(l:context.parents) - 1)
-      let l:parent = l:context.parents[l:i - 1]
-      let l:node = l:context.parents[l:i]
+  let l:folding_targets = l:context.parents + [l:context.node]
+  if len(l:folding_targets) > 1
+    for l:i in range(1, len(l:folding_targets) - 1)
+      let l:parent = l:folding_targets[l:i - 1]
+      let l:node = l:folding_targets[l:i]
       if get(l:node, 'follower', v:false)
         let l:index = index(l:parent.children, l:node)
         call remove(l:parent.children, l:index)

--- a/autoload/vsnip/snippet/node.vim
+++ b/autoload/vsnip/snippet/node.vim
@@ -7,7 +7,7 @@ let s:Text = vsnip#snippet#node#text#import()
 "
 function! vsnip#snippet#node#create_from_ast(ast) abort
   if type(a:ast) == type([])
-    return map(a:ast, { k, v -> vsnip#snippet#node#create_from_ast(v) })
+    return map(a:ast, 'vsnip#snippet#node#create_from_ast(v:val)')
   endif
 
   if a:ast.type ==# 'placeholder'

--- a/autoload/vsnip/snippet/node/placeholder.vim
+++ b/autoload/vsnip/snippet/node/placeholder.vim
@@ -1,4 +1,5 @@
 let s:max_tabstop = 1000000
+let s:uid = 0
 
 function! vsnip#snippet#node#placeholder#import() abort
   return s:Placeholder
@@ -10,7 +11,10 @@ let s:Placeholder = {}
 " new.
 "
 function! s:Placeholder.new(ast) abort
+  let s:uid += 1
+
   let l:node = extend(deepcopy(s:Placeholder), {
+  \   'uid': s:uid,
   \   'type': 'placeholder',
   \   'id': a:ast.id,
   \   'is_final': a:ast.id == 0,
@@ -27,8 +31,6 @@ function! s:Placeholder.new(ast) abort
     let l:node.children = [vsnip#snippet#node#create_text('')]
   endif
 
-  function! l:node.unique()
-  endfunction
   return l:node
 endfunction
 

--- a/autoload/vsnip/snippet/node/text.vim
+++ b/autoload/vsnip/snippet/node/text.vim
@@ -1,3 +1,5 @@
+let s:uid = 0
+
 function! vsnip#snippet#node#text#import() abort
   return s:Text
 endfunction
@@ -8,14 +10,14 @@ let s:Text = {}
 " new.
 "
 function! s:Text.new(ast) abort
-  let l:node = extend(deepcopy(s:Text), {
+  let s:uid += 1
+
+  return extend(deepcopy(s:Text), {
+  \   'uid': s:uid,
   \   'type': 'text',
   \   'value': a:ast.escaped,
+  \   'children': [],
   \ })
-
-  function! l:node.unique()
-  endfunction
-  return l:node
 endfunction
 
 "


### PR DESCRIPTION
Fixes #97, #105 

This PR aims to provide a detailed context for the traverse callback.

It can be useful for some situations.

#### Fix indentation for $TM_SELECTED_TEXT
Currently, The indentation fixing did not care about the base-indent of snippet's first-line.

#### Improve perf
- It makes the ability to avoid duplicate `a:node.text()` call.

Currently, the all tests are passed.
