### PR TITLE
WIP: Snippet traversing should use post-order

### DIFF
--- a/autoload/vsnip/parser/combinator.vim
+++ b/autoload/vsnip/parser/combinator.vim
@@ -169,7 +169,7 @@ function! s:pattern(pattern) abort
   function! l:fn.parse(text, pos) abort
     let l:text = strcharpart(a:text, a:pos)
     let l:matches = matchstrpos(l:text, self.pattern, 0, 1)
-    if l:matches[0] !=# ''
+    if l:matches[1] != -1
       return [v:true, l:matches[0], a:pos + l:matches[2]]
     endif
     return [v:false, v:null, a:pos]

--- a/autoload/vsnip/snippet.vim
+++ b/autoload/vsnip/snippet.vim
@@ -420,27 +420,8 @@ function! s:Snippet.traverse(node, callback) abort
   call s:traverse(a:node, a:callback, l:state, l:context)
 endfunction
 function! s:traverse(node, callback, state, context) abort
-  let l:text = ''
-  let l:length = 0
-  if a:node.type !=# 'snippet'
-    let l:text = a:node.text()
-    let l:length = strchars(l:text)
-    if a:callback({
-    \   'node': a:node,
-    \   'text': l:text,
-    \   'length': l:length,
-    \   'parent': a:context.parent,
-    \   'parents': a:context.parents,
-    \   'depth': a:context.depth,
-    \   'offset': a:state.offset,
-    \   'before_text': a:state.before_text,
-    \   'range': [a:state.offset, a:state.offset + l:length],
-    \ })
-      return v:true
-    endif
-  endif
-
-  if len(a:node.children) > 0
+  let l:has_children = len(a:node.children) > 0
+  if l:has_children
     let l:next_context = {
       \   'parent': a:node,
       \   'parents': a:context.parents + [a:node],
@@ -451,9 +432,28 @@ function! s:traverse(node, callback, state, context) abort
         return v:true
       endif
     endfor
-  else
-    let a:state.before_text .= l:text
-    let a:state.offset += l:length
+  endif
+
+  if a:node.type !=# 'snippet'
+    let l:text = a:node.text()
+    let l:length = strchars(l:text)
+    if a:callback({
+    \   'node': a:node,
+    \   'text': l:text,
+    \   'length': l:length,
+    \   'parent': a:context.parent,
+    \   'parents': a:context.parents,
+    \   'depth': a:context.depth,
+    \   'offset': a:state.offset - l:length,
+    \   'before_text': a:state.before_text,
+    \   'range': [a:state.offset - l:length, a:state.offset],
+    \ })
+      return v:true
+    endif
+    if !l:has_children
+      let a:state.before_text .= l:text
+      let a:state.offset += l:length
+    endif
   endif
 endfunction
 

--- a/autoload/vsnip/snippet/parser.vim
+++ b/autoload/vsnip/snippet/parser.vim
@@ -130,12 +130,12 @@ let s:variable3 = s:map(s:seq(
 \   s:open,
 \   s:varname,
 \   s:colon,
-\   s:or(s:any, s:text(['$', '}'], [])),
+\   s:many(s:or(s:any, s:text(['$', '}'], []))),
 \   s:close
 \ ), { value -> {
 \   'type': 'variable',
 \   'name': value[2],
-\   'children': [value[4]]
+\   'children': value[4]
 \ } })
 let s:variable4 = s:map(s:seq(s:dollar, s:open, s:varname, s:transform, s:close), { value -> {
 \   'type': 'variable',


### PR DESCRIPTION
This PR aims to improve snippet nodes traversing.

It can be enable for the below snippets.

```
{
  "fname": {
    "prefix": ["fname"],
    "body": ["$TM_FILENAME_BASE"]
  },
  "Fname": {
    "prefix": ["Fname"],
    "body": ["${VIM:substitute('$TM_FILENAME_BASE', '.*', '\\u\\0', 'g')}"]
  }
}
```

The `Fname` snippet behaves like a transform feature.

I know, we should support `VSCode` transform feature for the snippet source file portability.
But it can be used for now.