### PR TITLE
fix: <BS> in select mode at end of line

### DIFF
--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -60,7 +60,7 @@ endfunction
 " extra mapping
 "
 if g:vsnip_extra_mapping
-  snoremap <BS> <BS>i
+  snoremap <expr> <bs> "\<BS>" . (getcurpos()[2] == col('$') - 1 ? 'a' : 'i')
 endif
 
 "


### PR DESCRIPTION
It fixes this issue:

![Imgur](https://imgur.com/mr1snUZ.gif)

Test snippet:
```json
    "try": {
        "body": [
            "try",
            "\t$TM_SELECTED_TEXT$1",
            "catch${2: /E${3:123:}/}$0",
            "endtry"
        ],
        "description": "try block",
        "prefix": [
            "try"
        ]
    },
```