### PR TITLE
Fix #129

### DIFF
--- a/.themisrc
+++ b/.themisrc
@@ -40,10 +40,6 @@ function! s:assert() abort
     unlet! g:vsnip_assert[l:key]
   endif
 
-  if len(keys(g:vsnip_assert)) == 0
-    call vsnip#deactivate()
-  endif
-
   return ''
 endfunction
 

--- a/autoload/vsnip/snippet.vim
+++ b/autoload/vsnip/snippet.vim
@@ -153,23 +153,23 @@ function! s:Snippet.follow(current_tabstop, diff) abort
     let l:context.node.value = l:new_text
   endfor
 
-  " Fold nodes when the edit was unexpected
-  let l:folded = []
+  " Squash nodes when the edit was unexpected
+  let l:squashed = []
   for l:context in l:fn.contexts
-    let l:folding_targets = l:context.parents + [l:context.node]
-    for l:i in range(len(l:folding_targets) - 1, 1, -1)
-      let l:node = l:folding_targets[l:i]
-      let l:parent = l:folding_targets[l:i - 1]
+    let l:squash_targets = l:context.parents + [l:context.node]
+    for l:i in range(len(l:squash_targets) - 1, 1, -1)
+      let l:node = l:squash_targets[l:i]
+      let l:parent = l:squash_targets[l:i - 1]
 
-      let l:should_fold = v:false
-      let l:should_fold = l:should_fold || get(l:node, 'follower', v:false)
-      let l:should_fold = l:should_fold || get(l:parent, 'id', v:null) is# a:current_tabstop
-      let l:should_fold = l:should_fold || !l:context.followed && strlen(l:node.text()) == 0
-      if l:should_fold && index(l:folded, l:node) == -1
+      let l:should_squash = v:false
+      let l:should_squash = l:should_squash || get(l:node, 'follower', v:false)
+      let l:should_squash = l:should_squash || get(l:parent, 'id', v:null) is# a:current_tabstop
+      let l:should_squash = l:should_squash || !l:context.followed && strlen(l:node.text()) == 0
+      if l:should_squash && index(l:squashed, l:node) == -1
         let l:index = index(l:parent.children, l:node)
         call remove(l:parent.children, l:index)
         call insert(l:parent.children, vsnip#snippet#node#create_text(l:node.text()), l:index)
-        call add(l:folded, l:node)
+        call add(l:squashed, l:node)
       endif
     endfor
   endfor

--- a/autoload/vsnip/snippet.vim
+++ b/autoload/vsnip/snippet.vim
@@ -98,7 +98,7 @@ function! s:Snippet.follow(current_tabstop, diff) abort
   let l:range = self.range()
   let l:in_range = v:true
   let l:in_range = l:in_range && (l:range.start.line < a:diff.range.start.line || l:range.start.line == a:diff.range.start.line && l:range.start.character <= a:diff.range.start.character)
-  let l:in_range = l:in_range && (l:range.end.line > a:diff.range.start.line || l:range.end.line == a:diff.range.end.line && l:range.end.character >= a:diff.range.end.character)
+  let l:in_range = l:in_range && (a:diff.range.end.line < l:range.end.line || a:diff.range.end.line == l:range.end.line && a:diff.range.end.character <= l:range.end.character)
   if !l:in_range
     return v:false
   endif
@@ -148,10 +148,8 @@ function! s:Snippet.follow(current_tabstop, diff) abort
 
     " Apply patched new text.
     let l:context.node.value = l:new_text
-  endfor
 
-  " Convert to text node when edited node is follower node.
-  for l:context in l:fn.contexts
+    " Fold nodes when the edit was unexpected
     let l:folding_targets = l:context.parents + [l:context.node]
     if len(l:folding_targets) > 1
       for l:i in range(1, len(l:folding_targets) - 1)

--- a/autoload/vsnip/snippet.vim
+++ b/autoload/vsnip/snippet.vim
@@ -140,7 +140,7 @@ function! s:Snippet.follow(current_tabstop, diff) abort
 
     " Create patched new text.
     let l:new_text = strcharpart(l:context.text, 0, l:start)
-    if l:context.parent.type ==# 'placeholder' && !l:followed
+    if !l:followed && (l:context.parent.type ==# 'placeholder' || l:context is l:fn.contexts[-1])
       let l:new_text .= l:diff_text
       let l:followed = v:true
     endif

--- a/spec/autoload/vsnip/snippet.vimspec
+++ b/spec/autoload/vsnip/snippet.vimspec
@@ -77,7 +77,7 @@ Describe vsnip#snippet
       call s:expect(l:snippet.text()).to_equal("class  {\n\tpublic default() {\n\t\t\n\t}\n}")
     End
 
-    It should follow to the whole range diff
+    It should follow when diff range covers whole of snippet
       let l:snippet = s:Snippet.new(s:start_position, "class $1 {\n\tpublic ${2:default}() {\n\t\t$0\n\t}\n}")
       let l:followed = l:snippet.follow(0, {
       \   'range': {
@@ -96,7 +96,49 @@ Describe vsnip#snippet
       call s:expect(l:snippet.text()).to_equal("")
     End
 
-    It should follow when diff range included by node range
+    It should squash placeholder when diff range covers multiple placeholders
+      let l:snippet = s:Snippet.new(s:start_position, "console.log(${1:first}, ${2:second})")
+      call s:expect(l:snippet.get_placeholder_nodes()).to_have_length(3)
+      let l:followed = l:snippet.follow(0, {
+      \   'range': {
+      \     'start': {
+      \       'line': 1,
+      \       'character': 13
+      \     },
+      \     'end': {
+      \       'line': 1,
+      \       'character': 26
+      \     }
+      \   },
+      \   'text': ''
+      \ })
+      call s:expect(l:followed).to_equal(v:true)
+      call s:expect(l:snippet.get_placeholder_nodes()).to_have_length(2)
+      call s:expect(l:snippet.text()).to_equal('console.log()')
+    End
+
+    It should not squash placeholder when diff range includes multiple placeholders but last one does not covered
+      let l:snippet = s:Snippet.new(s:start_position, "console.log(${1:first}, ${2:second})")
+      call s:expect(l:snippet.get_placeholder_nodes()).to_have_length(3)
+      let l:followed = l:snippet.follow(0, {
+      \   'range': {
+      \     'start': {
+      \       'line': 1,
+      \       'character': 13
+      \     },
+      \     'end': {
+      \       'line': 1,
+      \       'character': 25
+      \     }
+      \   },
+      \   'text': ''
+      \ })
+      call s:expect(l:followed).to_equal(v:true)
+      call s:expect(l:snippet.get_placeholder_nodes()).to_have_length(3)
+      call s:expect(l:snippet.text()).to_equal('console.log(d)')
+    End
+
+    It should follow when diff range is within one node range
       let l:snippet = s:Snippet.new(s:start_position, "class $1 {\n\tpublic ${2:default}() {\n\t\t$0\n\t}\n}")
       call l:snippet.follow(0, {
       \   'range': {
@@ -115,7 +157,7 @@ Describe vsnip#snippet
       call s:expect(l:snippet.get_next_jump_point(1).placeholder.text()).to_equal('d___ult')
     End
 
-    It should follow when diff range included only text-node
+    It should follow when diff range included only text node
       let l:snippet = s:Snippet.new(s:start_position, "class $1 {\n\tpublic ${2:default}() {\n\t\t$0\n\t}\n}")
       call l:snippet.follow(1, {
       \   'range': {

--- a/spec/autoload/vsnip/snippet.vimspec
+++ b/spec/autoload/vsnip/snippet.vimspec
@@ -95,6 +95,24 @@ Describe vsnip#snippet
       call s:expect(l:snippet.get_next_jump_point(1).placeholder.text()).to_equal('d___ult')
     End
 
+    It should follow when diff range included only text-node
+      let l:snippet = s:Snippet.new(s:start_position, "class $1 {\n\tpublic ${2:default}() {\n\t\t$0\n\t}\n}")
+      call l:snippet.follow(1, {
+      \   'range': {
+      \     'start': {
+      \       'line': 1,
+      \       'character': 1
+      \     },
+      \     'end': {
+      \       'line': 1,
+      \       'character': 6
+      \     }
+      \   },
+      \   'text': 'modified'
+      \ })
+      call s:expect(l:snippet.text()).to_equal("modified  {\n\tpublic default() {\n\t\t\n\t}\n}")
+    End
+
     It should prefer placeholder node than text node when both followable (left)
       let l:snippet = s:Snippet.new(s:start_position, '[${1:text1}][${2:text2}][${3:text3}]')
       call l:snippet.follow(1, {

--- a/spec/autoload/vsnip/snippet.vimspec
+++ b/spec/autoload/vsnip/snippet.vimspec
@@ -60,20 +60,40 @@ Describe vsnip#snippet
 
     It should not affect following empty diff
       let l:snippet = s:Snippet.new(s:start_position, "class $1 {\n\tpublic ${2:default}() {\n\t\t$0\n\t}\n}")
-      call l:snippet.follow(0, {
+      let l:followed = l:snippet.follow(0, {
       \   'range': {
       \     'start': {
-      \       'line': 0,
-      \       'character': 0
+      \       'line': 1,
+      \       'character': 1
       \     },
       \     'end': {
-      \       'line': 0,
-      \       'character': 0
+      \       'line': 1,
+      \       'character': 1
       \     }
       \   },
       \   'text': ''
       \ })
+      call s:expect(l:followed).to_equal(v:true)
       call s:expect(l:snippet.text()).to_equal("class  {\n\tpublic default() {\n\t\t\n\t}\n}")
+    End
+
+    It should follow to the whole range diff
+      let l:snippet = s:Snippet.new(s:start_position, "class $1 {\n\tpublic ${2:default}() {\n\t\t$0\n\t}\n}")
+      let l:followed = l:snippet.follow(0, {
+      \   'range': {
+      \     'start': {
+      \       'line': 1,
+      \       'character': 1
+      \     },
+      \     'end': {
+      \       'line': 5,
+      \       'character': 1
+      \     }
+      \   },
+      \   'text': ''
+      \ })
+      call s:expect(l:followed).to_equal(v:true)
+      call s:expect(l:snippet.text()).to_equal("")
     End
 
     It should follow when diff range included by node range

--- a/spec/autoload/vsnip/snippet.vimspec
+++ b/spec/autoload/vsnip/snippet.vimspec
@@ -58,58 +58,22 @@ Describe vsnip#snippet
 
   Describe #follow
 
-    It should not follow when diff range includes nodes border(left)
+    It should not affect following empty diff
       let l:snippet = s:Snippet.new(s:start_position, "class $1 {\n\tpublic ${2:default}() {\n\t\t$0\n\t}\n}")
-      let l:followed = l:snippet.follow(0, {
+      call l:snippet.follow(0, {
       \   'range': {
       \     'start': {
-      \       'line': 2,
-      \       'character': 1
+      \       'line': 0,
+      \       'character': 0
       \     },
       \     'end': {
-      \       'line': 2,
-      \       'character': 12
+      \       'line': 0,
+      \       'character': 0
       \     }
       \   },
-      \   'text': '___'
+      \   'text': ''
       \ })
-      call s:expect(l:followed).to_equal(v:false)
-    End
-
-    It should not follow when diff range includes nodes border(right)
-      let l:snippet = s:Snippet.new(s:start_position, "class $1 {\n\tpublic ${2:default}() {\n\t\t$0\n\t}\n}")
-      let l:followed = l:snippet.follow(0, {
-      \   'range': {
-      \     'start': {
-      \       'line': 2,
-      \       'character': 12
-      \     },
-      \     'end': {
-      \       'line': 2,
-      \       'character': 17
-      \     }
-      \   },
-      \   'text': '___(params)'
-      \ })
-      call s:expect(l:followed).to_equal(v:false)
-    End
-
-    It should not follow when diff range is overlap multiple nodes
-      let l:snippet = s:Snippet.new(s:start_position, "class $1 {\n\tpublic ${2:default}() {\n\t\t$0\n\t}\n}")
-      let l:followed = l:snippet.follow(0, {
-      \   'range': {
-      \     'start': {
-      \       'line': 2,
-      \       'character': 7
-      \     },
-      \     'end': {
-      \       'line': 2,
-      \       'character': 16
-      \     }
-      \   },
-      \   'text': '___'
-      \ })
-      call s:expect(l:followed).to_equal(v:false)
+      call s:expect(l:snippet.text()).to_equal("class  {\n\tpublic default() {\n\t\t\n\t}\n}")
     End
 
     It should follow when diff range included by node range

--- a/spec/plugin/vsnip.vimspec
+++ b/spec/plugin/vsnip.vimspec
@@ -2,6 +2,10 @@ let s:expect = themis#helper('expect')
 
 Describe vsnip
 
+  After each
+    call vsnip#deactivate()
+  End
+
   Context expand
 
     It should expand when prefix start col is 1


### PR DESCRIPTION
Implement #129 feature.

Currently, existing tests were passing but we should decide the spec and add tests for it.

1. When diff range included multiple placeholders.
    1. Which nodes are we should prefer?
    2. Non-preferred nodes are we should fold?
2. More wisely snippet deactivation.
    1. this feature makes it harder to deactivate the snippet session.

#### TODO
- [x] Implement
- [x] Add tests
- [x] Consider snippet deactivation
- [x] Remove unneeded placeholder after followed


![vsnip-issue-129](https://user-images.githubusercontent.com/629908/91849724-75469c00-ec97-11ea-8852-94497b8fad96.gif)
