### PR TITLE
fix: can't refresh snippet inside a symlink

### DIFF
--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -180,6 +180,6 @@ endfunction
 " on_buf_write_post
 "
 function! s:on_buf_write_post() abort
-  call vsnip#source#refresh(fnamemodify(bufname('%'), ':p'))
+  call vsnip#source#refresh(resolve(fnamemodify(bufname('%'), ':p')))
 endfunction
 


### PR DESCRIPTION
Fix update fails if snippet directory is in a symbolic link.
In source, calls `resolve()` at file reading, but autocmd doesn't call it, so I changed to call it.