### PR TITLE
use '+' register when clipboard set to unnamedplus

### DIFF
--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -63,6 +63,7 @@ function! s:add_command(start, end, name) abort
   let name = empty(a:name) ? 'new' : a:name
 
   let reg = &clipboard =~# 'unnamed' ? '*' : '"'
+  let reg = &clipboard =~# 'unnamedplus' ? '+' : reg
   call setreg(reg, printf(format, name, name, join(lines, ",\n      ")), 'l')
 endfunction
 


### PR DESCRIPTION
When register is set to "unnamedplus". It should be yanked to "+" register. 