### PR TITLE
Expand g:vsnip_snippet_dir when checking existance

### DIFF
--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -41,17 +41,18 @@ function! s:open_command(bang, cmd)
     endif
   endif
 
-  if !isdirectory(g:vsnip_snippet_dir)
+  let l:expanded_dir = expand(g:vsnip_snippet_dir)
+  if !isdirectory(l:expanded_dir)
     let l:prompt = printf('`%s` does not exists, create? y(es)/n(o): ', g:vsnip_snippet_dir)
     if index(['y', 'ye', 'yes'], input(l:prompt)) >= 0
-      call mkdir(g:vsnip_snippet_dir, 'p')
+      call mkdir(l:expanded_dir, 'p')
     else
       return
     endif
   endif
 
   execute printf('%s %s', a:cmd, fnameescape(printf('%s/%s.json',
-  \   resolve(expand(g:vsnip_snippet_dir)),
+  \   resolve(l:expanded_dir),
   \   l:candidates[l:idx - 1]
   \ )))
 endfunction


### PR DESCRIPTION
Without this change, setting `vsnip_snippet_dir` to a filepath that is not expanded, i.e. `let g:vsnip_snippet_dir = "~/.vim/snippets"`, would lead to `:VsnipOpen` asking whether to create the directory or not - even if it exists.