### PR TITLE
Add `VIM_CAMELCASE_FILENAME` variable

### DIFF
--- a/autoload/vsnip/variable.vim
+++ b/autoload/vsnip/variable.vim
@@ -176,3 +176,9 @@ function! s:VIM(context) abort
 endfunction
 call vsnip#variable#register('VIM', function('s:VIM'))
 
+function! s:VSNIP_CAMELCASE_FILENAME(context) abort
+  let l:basename = substitute(expand('%:p:t'), '^\@<!\..*$', '', '')
+  return substitute(l:basename, '\(\%(\<\l\+\)\%(_\)\@=\)\|_\(\l\)', '\u\1\2', 'g')
+endfunction
+call vsnip#variable#register('VSNIP_CAMELCASE_FILENAME', function('s:VSNIP_CAMELCASE_FILENAME'))
+

--- a/doc/vsnip.txt
+++ b/doc/vsnip.txt
@@ -218,6 +218,7 @@ For inserting line or block comments, honoring the current language:
 
 In addition, vsnip provides the below custom variables too.
 
+  `VSNIP_CAMELCASE_FILENAME`   The filename of the current document without its extensions in CamelCase format
 
 ${VIM:...Vim script expression...}~
 


### PR DESCRIPTION
Transform filename to CamelCase format. Useful for class name.
`tmp/example/super_script.rb` => `SuperScript`

![VSNIP_CAMELCASE_FILENAME](https://user-images.githubusercontent.com/1897405/124418481-fe75a600-dd74-11eb-8e57-2be110d5892c.gif)



