### PR TITLE
Support whole word transform on tabstop and variable

### DIFF
--- a/autoload/vsnip/snippet.vim
+++ b/autoload/vsnip/snippet.vim
@@ -200,7 +200,7 @@ function! s:Snippet.sync() abort
           call add(self.targets, {
           \   'range': a:context.range,
           \   'node': a:context.node,
-          \   'new_text': self.new_texts[a:context.node.id],
+          \   'new_text': a:context.node.transform.text(self.new_texts[a:context.node.id]),
           \ })
         endif
       endif

--- a/autoload/vsnip/snippet/node.vim
+++ b/autoload/vsnip/snippet/node.vim
@@ -1,6 +1,7 @@
 let s:Placeholder = vsnip#snippet#node#placeholder#import()
 let s:Variable = vsnip#snippet#node#variable#import()
 let s:Text = vsnip#snippet#node#text#import()
+let s:Transform = vsnip#snippet#node#transform#import()
 
 "
 " vsnip#snippet#node#create_from_ast
@@ -32,4 +33,11 @@ function! vsnip#snippet#node#create_text(text) abort
   \   'raw': a:text,
   \   'escaped': a:text
   \ })
+endfunction
+
+"
+" vsnip#snippet#node#create_transform
+"
+function! vsnip#snippet#node#create_transform(transform) abort
+  return s:Transform.new(a:transform)
 endfunction

--- a/autoload/vsnip/snippet/node/placeholder.vim
+++ b/autoload/vsnip/snippet/node/placeholder.vim
@@ -21,6 +21,7 @@ function! s:Placeholder.new(ast) abort
   \   'follower': v:false,
   \   'choice': get(a:ast, 'choice', []),
   \   'children': vsnip#snippet#node#create_from_ast(get(a:ast, 'children', [])),
+  \   'transform': vsnip#snippet#node#create_transform(get(a:ast, 'transform')),
   \ })
 
   if l:node.is_final

--- a/autoload/vsnip/snippet/node/transform.vim
+++ b/autoload/vsnip/snippet/node/transform.vim
@@ -38,12 +38,16 @@ function! s:Transform.text(input_text) abort
   let l:text = ''
  
   for l:replacement in self.replacements
-    if l:replacement.modifier ==# '/capitalize'
-      let l:text = toupper(strpart(a:input_text, 0, 1)) . strpart(a:input_text, 1)
-    elseif l:replacement.modifier ==# '/downcase'
-      let l:text = tolower(a:input_text)
-    elseif l:replacement.modifier ==# '/upcase'
-      let l:text = toupper(a:input_text)
+    if l:replacement.type ==# 'format'
+      if l:replacement.modifier ==# '/capitalize'
+        let l:text .= toupper(strpart(a:input_text, 0, 1)) . strpart(a:input_text, 1)
+      elseif l:replacement.modifier ==# '/downcase'
+        let l:text .= tolower(a:input_text)
+      elseif l:replacement.modifier ==# '/upcase'
+        let l:text .= toupper(a:input_text)
+      endif
+    elseif l:replacement.type ==# 'text'
+      let l:text .= l:replacement.escaped
     endif
   endfor
 

--- a/autoload/vsnip/snippet/node/transform.vim
+++ b/autoload/vsnip/snippet/node/transform.vim
@@ -19,6 +19,16 @@ function! s:capitalize(word)
   return word
 endfunction
 
+" https://github.com/tpope/vim-abolish/blob/3f0c8faa/plugin/abolish.vim#L111-L118
+function! s:camelcase(word)
+  let word = substitute(a:word, '-', '_', 'g')
+  if word !~# '_' && word =~# '\l'
+    return substitute(word,'^.','\l&','')
+  else
+    return substitute(word,'\C\(_\)\=\(.\)','\=submatch(1)==""?tolower(submatch(2)) : toupper(submatch(2))','g')
+  endif
+endfunction
+
 "
 " new.
 "
@@ -60,6 +70,10 @@ function! s:Transform.text(input_text) abort
         let l:text .= s:downcase(a:input_text)
       elseif l:replacement.modifier ==# '/upcase'
         let l:text .= s:upcase(a:input_text)
+      elseif l:replacement.modifier ==# '/camelcase'
+        let l:text .= s:camelcase(a:input_text)
+      elseif l:replacement.modifier ==# '/pascalcase'
+        let l:text .= s:capitalize(s:camelcase(a:input_text))
       endif
     elseif l:replacement.type ==# 'text'
       let l:text .= l:replacement.escaped

--- a/autoload/vsnip/snippet/node/transform.vim
+++ b/autoload/vsnip/snippet/node/transform.vim
@@ -4,6 +4,21 @@ endfunction
 
 let s:Transform = {}
 
+function! s:upcase(word)
+  let word = toupper(a:word)
+  return word
+endfunction
+
+function! s:downcase(word)
+  let word = tolower(a:word)
+  return word
+endfunction
+
+function! s:capitalize(word)
+  let word = s:upcase(strpart(a:word, 0, 1)) . strpart(a:word, 1)
+  return word
+endfunction
+
 "
 " new.
 "
@@ -40,11 +55,11 @@ function! s:Transform.text(input_text) abort
   for l:replacement in self.replacements
     if l:replacement.type ==# 'format'
       if l:replacement.modifier ==# '/capitalize'
-        let l:text .= toupper(strpart(a:input_text, 0, 1)) . strpart(a:input_text, 1)
+        let l:text .= s:capitalize(a:input_text)
       elseif l:replacement.modifier ==# '/downcase'
-        let l:text .= tolower(a:input_text)
+        let l:text .= s:downcase(a:input_text)
       elseif l:replacement.modifier ==# '/upcase'
-        let l:text .= toupper(a:input_text)
+        let l:text .= s:upcase(a:input_text)
       endif
     elseif l:replacement.type ==# 'text'
       let l:text .= l:replacement.escaped

--- a/autoload/vsnip/snippet/node/transform.vim
+++ b/autoload/vsnip/snippet/node/transform.vim
@@ -1,0 +1,67 @@
+function! vsnip#snippet#node#transform#import() abort
+  return s:Transform
+endfunction
+
+let s:Transform = {}
+
+"
+" new.
+"
+function! s:Transform.new(ast) abort
+  let l:transform = empty(a:ast) ? {} : a:ast
+
+  let l:node = extend(deepcopy(s:Transform), {
+  \   'type': 'transform',
+  \   'regex': get(l:transform, 'regex', v:null),
+  \   'replacements': get(l:transform, 'format', []),
+  \   'options': get(l:transform, 'option', []),
+  \ })
+
+  let l:node.is_noop = l:node.regex is v:null
+
+  return l:node
+endfunction
+
+"
+" text.
+"
+function! s:Transform.text(input_text) abort
+  if empty(a:input_text) || self.is_noop
+    return a:input_text
+  endif
+
+  if self.regex.pattern !=# '(.*)'
+    " TODO: fully support regex
+    return a:input_text
+  endif
+
+  let l:text = ''
+ 
+  for l:replacement in self.replacements
+    if l:replacement.modifier ==# '/capitalize'
+      let l:text = toupper(strpart(a:input_text, 0, 1)) . strpart(a:input_text, 1)
+    elseif l:replacement.modifier ==# '/downcase'
+      let l:text = tolower(a:input_text)
+    elseif l:replacement.modifier ==# '/upcase'
+      let l:text = toupper(a:input_text)
+    endif
+  endfor
+
+  return l:text
+endfunction
+
+"
+" to_string
+"
+function! s:Transform.to_string() abort
+  if self.is_noop
+    return
+  end
+
+  return printf('%s(regex=%s, total_replacements=%s, options=%s)',
+  \   self.type,
+  \   get(self.regex, 'pattern', ''),
+  \   len(self.replacements),
+  \   join(self.options, ''),
+  \ )
+endfunction

--- a/autoload/vsnip/snippet/node/variable.vim
+++ b/autoload/vsnip/snippet/node/variable.vim
@@ -23,6 +23,7 @@ function! s:Variable.new(ast) abort
   \   'unknown': empty(l:resolver),
   \   'resolver': l:resolver,
   \   'children': vsnip#snippet#node#create_from_ast(get(a:ast, 'children', [])),
+  \   'transform': vsnip#snippet#node#create_transform(get(a:ast, 'transform')),
   \ })
 endfunction
 
@@ -30,7 +31,7 @@ endfunction
 " text.
 "
 function! s:Variable.text() abort
-  return join(map(copy(self.children), 'v:val.text()'), '')
+  return self.transform.text(join(map(copy(self.children), 'v:val.text()'), ''))
 endfunction
 
 "
@@ -38,7 +39,7 @@ endfunction
 "
 function! s:Variable.resolve(context) abort
   if !self.unknown
-    let l:resolved = self.resolver.func({ 'node': self })
+    let l:resolved = self.transform.text(self.resolver.func({ 'node': self }))
     if l:resolved isnot v:null
       " Fix indent when one variable returns multiple lines
       let l:base_indent = vsnip#indent#get_base_indent(split(a:context.before_text, "\n", v:true)[-1])

--- a/autoload/vsnip/snippet/parser.vim
+++ b/autoload/vsnip/snippet/parser.vim
@@ -82,6 +82,8 @@ let s:format3 = s:map(
 \     s:token('/upcase'),
 \     s:token('/downcase'),
 \     s:token('/capitalize'),
+\     s:token('/camelcase'),
+\     s:token('/pascalcase'),
 \     s:token('+if'),
 \     s:token('?if:else'),
 \     s:token('-else'),

--- a/spec/autoload/vsnip/snippet.vimspec
+++ b/spec/autoload/vsnip/snippet.vimspec
@@ -31,6 +31,11 @@ Describe vsnip#snippet
       let l:snippet = s:Snippet.new(s:start_position, 'console.log(${CURRENT_YEAR})')
       call s:expect(l:snippet.text()).to_equal('console.log(' . strftime('%Y') . ')')
     End
+
+    It should support whole word transform
+      let l:snippet = s:Snippet.new(s:start_position, '${1:state}, set${1/(.*)/${1:/capitalize}/}')
+      call s:expect(l:snippet.text()).to_equal('state, setState')
+    End
   End
 
   Describe #sync
@@ -259,6 +264,22 @@ Describe vsnip#snippet
       call s:expect(l:snippet.text()).to_equal('default')
     End
 
+    It should support whole word transform (upcase) on tabstop
+      let l:snippet = s:Snippet.new(s:start_position, '${1:varName}, ${1/(.*)/${1:/upcase}/}')
+      call s:expect(l:snippet.text()).to_equal('varName, VARNAME')
+    End
+
+    It should support whole word transform (downcase) on variable
+      call vsnip#selected_text('varName')
+      let l:snippet = s:Snippet.new(s:start_position, '${TM_SELECTED_TEXT/(.*)/${1:/downcase}/}')
+      call s:expect(l:snippet.text()).to_equal('varname')
+    End
+
+    It should support whole word transform (capitalize)
+      call vsnip#selected_text('varName')
+      let l:snippet = s:Snippet.new(s:start_position, '${TM_SELECTED_TEXT/(.*)/${1:/capitalize}/}')
+      call s:expect(l:snippet.text()).to_equal('VarName')
+    End
   End
 
   Describe #range

--- a/spec/autoload/vsnip/snippet.vimspec
+++ b/spec/autoload/vsnip/snippet.vimspec
@@ -280,6 +280,12 @@ Describe vsnip#snippet
       let l:snippet = s:Snippet.new(s:start_position, '${TM_SELECTED_TEXT/(.*)/${1:/capitalize}/}')
       call s:expect(l:snippet.text()).to_equal('VarName')
     End
+
+    It should support whole word transform with additional text
+      call vsnip#selected_text('varName')
+      let l:snippet = s:Snippet.new(s:start_position, '${TM_SELECTED_TEXT/(.*)/start-lowercase-${1:/downcase}/}-end')
+      call s:expect(l:snippet.text()).to_equal('start-lowercase-varname-end')
+    End
   End
 
   Describe #range

--- a/spec/autoload/vsnip/snippet.vimspec
+++ b/spec/autoload/vsnip/snippet.vimspec
@@ -281,6 +281,40 @@ Describe vsnip#snippet
       call s:expect(l:snippet.text()).to_equal('VarName')
     End
 
+    It should support whole word transform (camelcase)
+      call vsnip#selected_text('var_name')
+      call s:expect(
+      \   s:Snippet.new(s:start_position, '${TM_SELECTED_TEXT/(.*)/${1:/camelcase}/}').text()
+      \ ).to_equal('varName')
+
+      call vsnip#selected_text('VAR_NAME')
+      call s:expect(
+      \   s:Snippet.new(s:start_position, '${TM_SELECTED_TEXT/(.*)/${1:/camelcase}/}').text()
+      \ ).to_equal('varName')
+
+      call vsnip#selected_text('VarName')
+      call s:expect(
+      \   s:Snippet.new(s:start_position, '${TM_SELECTED_TEXT/(.*)/${1:/camelcase}/}').text()
+      \ ).to_equal('varName')
+    End
+
+    It should support whole word transform (pascalcase)
+      call vsnip#selected_text('var_name')
+      call s:expect(
+      \   s:Snippet.new(s:start_position, '${TM_SELECTED_TEXT/(.*)/${1:/pascalcase}/}').text()
+      \ ).to_equal('VarName')
+
+      call vsnip#selected_text('VAR_NAME')
+      call s:expect(
+      \   s:Snippet.new(s:start_position, '${TM_SELECTED_TEXT/(.*)/${1:/pascalcase}/}').text()
+      \ ).to_equal('VarName')
+
+      call vsnip#selected_text('varName')
+      call s:expect(
+      \   s:Snippet.new(s:start_position, '${TM_SELECTED_TEXT/(.*)/${1:/pascalcase}/}').text()
+      \ ).to_equal('VarName')
+    End
+
     It should support whole word transform with additional text
       call vsnip#selected_text('varName')
       let l:snippet = s:Snippet.new(s:start_position, '${TM_SELECTED_TEXT/(.*)/start-lowercase-${1:/downcase}/}-end')


### PR DESCRIPTION
- Add missing `/camelcase` and `/pascalcase` from the [Grammar](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_grammar).
- Support **whole word** transform
  - supported regex: `(.*)` (i.e. the whole word)
  - supported formats: `'/upcase' | '/downcase' | '/capitalize' | '/camelcase' | '/pascalcase'`

Related to: https://github.com/hrsh7th/vim-vsnip/issues/83#issuecomment-856075164 https://github.com/hrsh7th/vim-vsnip/issues/209

This helps with my React.js snippet;

```json
{
  "useState": {
    "prefix": "us",
    "body": "const [${1:state}, set${1/(.*)/${1:/capitalize}/}] = useState(${2:initial${1/(.*)/${1:/capitalize}/}})$0",
    "description": "hook: useState"
  }
}
```