### PR TITLE
Use strlen() instead of strchars() to avoid multibyte bug

### DIFF
--- a/autoload/vsnip/session.vim
+++ b/autoload/vsnip/session.vim
@@ -157,7 +157,7 @@ function! s:Session.move(jump_point) abort
 
   call cursor(l:pos)
 
-  if l:pos[1] > strchars(getline(l:pos[0]))
+  if l:pos[1] > strlen(getline(l:pos[0]))
     startinsert!
   else
     startinsert

--- a/misc/integration.json
+++ b/misc/integration.json
@@ -69,6 +69,20 @@
       "$1snip${2:pet}"
     ]
   },
+  "multi1": {
+    "description": "jump at middle of snippet",
+    "prefix": ["マルチ1"],
+    "body": [
+      "あ$1い$2う"
+    ]
+  },
+  "multi2": {
+    "description": "select 4 length middle of snippet text",
+    "prefix": ["マルチ2"],
+    "body": [
+      "あ$1い${2:かkaか}う"
+    ]
+  },
   "realworld1": {
     "description": "Complex example",
     "prefix": ["realworld1"],

--- a/spec/plugin/vsnip.vimspec
+++ b/spec/plugin/vsnip.vimspec
@@ -218,6 +218,40 @@ Describe vsnip
 
   End
 
+  Context multiByte
+
+    It should jump to middle of snippet
+      enew!
+      set filetype=integration
+      call setline(1, 'マルチ1')
+      call cursor([1, 10])
+
+      let g:vsnip_assert = {}
+      function g:vsnip_assert.step1()
+        call s:expect(getcurpos()[1 : 2]).to_equal([1, 7])
+        call s:expect(getbufline('%', '^', '$')).to_equal(['あいう'])
+      endfunction
+      call feedkeys("a\<C-j>\<Tab>\<Plug>(vsnip-assert)", 'x')
+    End
+
+    It should select 4 length middle of snippet text 
+      enew!
+      set filetype=integration
+      call setline(1, 'マルチ2')
+      call cursor([1, 10])
+
+      let g:vsnip_assert = {}
+      function g:vsnip_assert.step1()
+        call s:expect(mode(1)).to_equal('s')
+        call s:expect(getpos("'<")[1 : 2]).to_equal([1, 7])
+        call s:expect(getpos("'>")[1 : 2]).to_equal([1, 12])
+        call s:expect(getbufline('%', '^', '$')).to_equal(['あいかkaかう'])
+      endfunction
+      call feedkeys("a\<C-j>\<Tab>\<Plug>(vsnip-assert)", 'x')
+    End
+
+  End
+
   Context realworld
 
     It should work (complex example)


### PR DESCRIPTION
This PR adds a fix to #228.
Using `strchars()` in [this line](https://github.com/hrsh7th/vim-vsnip/blob/39e41dca42c802ae655855dc816001ead8c0267b/autoload/vsnip/session.vim#L137) is correct, but `strlen()` should be used [here](https://github.com/hrsh7th/vim-vsnip/blob/39e41dca42c802ae655855dc816001ead8c0267b/autoload/vsnip/session.vim#L160) because `lsp_to_vim()` returns byteidx.

I also added tests for multibyte characters.
Since I'm not confident about tests, please fix if needed.