### PR TITLE
Implement $RELATIVE_FILEPATH

### DIFF
--- a/autoload/vsnip/variable.vim
+++ b/autoload/vsnip/variable.vim
@@ -73,6 +73,11 @@ function! s:TM_FILEPATH(context) abort
 endfunction
 call vsnip#variable#register('TM_FILEPATH', function('s:TM_FILEPATH'))
 
+function! s:RELATIVE_FILEPATH(context) abort
+  return expand('%')
+endfunction
+call vsnip#variable#register('RELATIVE_FILEPATH', function('s:RELATIVE_FILEPATH'))
+
 function! s:CLIPBOARD(context) abort
   let l:clipboard = getreg(v:register)
   if empty(l:clipboard)

--- a/doc/vsnip.txt
+++ b/doc/vsnip.txt
@@ -179,6 +179,7 @@ The following variables can be used in the same way they are in VSCode:
   `TM_FILENAME_BASE`         The filename of the current document without its extensions
   `TM_DIRECTORY`             The directory of the current document
   `TM_FILEPATH`              The full file path of the current document
+  `RELATIVE_FILEPATH`        The relative (to the current working directory) file path of the current document
   `CLIPBOARD`                The contents of your clipboard
   `WORKSPACE_NAME`           The name of the opened workspace or folder
 


### PR DESCRIPTION
Implement $RELATIVE_FILEPATH

As per docs in [VS Code](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables):

> `RELATIVE_FILEPATH` The relative (to the opened workspace or folder) file path of the current document

I've taken `to the opened workspace or folder` to mean current working directory in Vim-land.