### PR TITLE
Update README for vim-easycomplete and remove obsoluted plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ VSCode(LSP)'s snippet feature in vim/nvim.
   - LSP-client
     - [vim-lsp](https://github.com/prabirshrestha/vim-lsp)
     - [vim-lsc](https://github.com/natebosch/vim-lsc)
+    - [yegappan-lsp](https://github.com/yegappan/lsp)
     - [LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim)
     - [neovim built-in lsp](https://github.com/neovim/neovim)
-    - [vim-lamp](https://github.com/hrsh7th/vim-lamp)
   - completion-engine
-    - [deoplete.nvim](https://github.com/Shougo/deoplete.nvim)
     - [asyncomplete.vim](https://github.com/prabirshrestha/asyncomplete.vim)
     - [vim-mucomplete](https://github.com/lifepillar/vim-mucomplete)
-    - [completion-nvim](https://github.com/nvim-lua/completion-nvim)
+    - [ddc.vim](https://github.com/Shougo/ddc.vim)
+    - [vim-easycompletion](https://github.com/jayli/vim-easycomplete)
 - Vim script interpolation
   - You can use Vim script interpolation as `${VIM:...Vim script expression...}`.
 - SnipMate-like syntax support


### PR DESCRIPTION
Follows up this PR https://github.com/hrsh7th/vim-vsnip-integ/pull/61. This PR is to update README.