### PR TITLE
Fixed error handling when json is invalid.

### DIFF
--- a/autoload/vsnip/source.vim
+++ b/autoload/vsnip/source.vim
@@ -36,7 +36,7 @@ function! vsnip#source#create(path) abort
     let l:file = iconv(l:file, 'utf-8', &encoding)
     let l:json = json_decode(l:file)
 
-    if type(l:json) != type({})
+    if type(l:json) != type({}) || json->keys() == "_TYPE_VAL"
       throw printf('%s is not valid json.', a:path)
     endif
   catch /.*/


### PR DESCRIPTION
When a key with the same name exists in the json of the created snippet, an error is displayed as follows
However, it is not possible to determine what is causing the error from this content.
![Screenshot from 2023-08-26 07-47-42](https://github.com/hrsh7th/vim-vsnip/assets/55862484/cd2324c0-87a7-4a06-bb5b-61f05aae8558)

Therefore, the error has been corrected so that the error is displayed as follows
![Screenshot from 2023-08-26 07-48-57](https://github.com/hrsh7th/vim-vsnip/assets/55862484/dbc3a9c0-36d1-4d89-adfc-e486d29d0841)
![Screenshot from 2023-08-26 07-49-47](https://github.com/hrsh7th/vim-vsnip/assets/55862484/76d03730-3619-46f0-836f-bcde0aae8912)
