### PR TITLE
Fix #272

### DIFF
--- a/autoload/vsnip/snippet/parser.vim
+++ b/autoload/vsnip/snippet/parser.vim
@@ -37,7 +37,7 @@ let s:slash = s:token('/')
 let s:comma = s:token(',')
 let s:pipe = s:token('|')
 let s:varname = s:pattern('[_[:alpha:]]\w*')
-let s:int = s:map(s:pattern('\d\+'), { value -> str2nr(value[0]) })
+let s:int = s:map(s:pattern('\d\+'), { value -> str2nr(value) })
 let s:text = { stop, escape -> s:map(
 \   s:skip(stop, escape),
 \   { value -> {


### PR DESCRIPTION
Since `s:seq()` is not used here, the first character of the string is taken out by `[0]`.
Fix #272 