### PR TITLE
Add `treesitter` integration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = off
+
+[*.{yaml,yml}]
+indent_size = 2

--- a/.github/workflows/linux_neovim.yml
+++ b/.github/workflows/linux_neovim.yml
@@ -46,4 +46,3 @@ jobs:
           themis ./spec
           export VIRTUALEDIT=1
           themis ./spec
-

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The snippet format was described in [here](https://code.visualstudio.com/docs/ed
 
 # Recipe
 
-### $TM_FILENAME_BASE
+### $TM\_FILENAME\_BASE
 
 You can insert the filename via `fname\<Plug>(vsnip-expand)`.
 
@@ -133,7 +133,7 @@ You can insert the filename via `fname\<Plug>(vsnip-expand)`.
 }
 ```
 
-### Log $TM_SELECTED_TEXT
+### Log $TM\_SELECTED\_TEXT
 
 You can fill `$TM_SELECTED_TEXT` by `<Plug>(vsnip-select-text)` or `<Plug>(vsnip-cut-text)`.
 
@@ -197,4 +197,3 @@ You can run `npm run test` after install [vim-themis](https://github.com/thinca/
 1. compute the `user-diff` ... `s:Session.flush_changes`
 2. reflect the `user-diff` to snippet ast ... `s:Snippet.follow`
 3. reflect the `sync-diff` to buffer content ... `s:Snippet.sync & s:Session.flush_changes`
-

--- a/autoload/vital/_vsnip/VS/LSP/Diff.vim
+++ b/autoload/vital/_vsnip/VS/LSP/Diff.vim
@@ -161,4 +161,3 @@ if has('nvim')
   catch /.*/
   endtry
 endif
-

--- a/autoload/vital/_vsnip/VS/LSP/Position.vim
+++ b/autoload/vital/_vsnip/VS/LSP/Position.vim
@@ -59,4 +59,3 @@ function! s:_get_buffer_line(expr, lnum) abort
   endif
   return v:null
 endfunction
-

--- a/autoload/vital/_vsnip/VS/LSP/Text.vim
+++ b/autoload/vital/_vsnip/VS/LSP/Text.vim
@@ -20,4 +20,3 @@ endfunction
 function! s:split_by_eol(text) abort
   return split(a:text, "\r\n\\|\r\\|\n", v:true)
 endfunction
-

--- a/autoload/vital/_vsnip/VS/LSP/TextEdit.vim
+++ b/autoload/vital/_vsnip/VS/LSP/TextEdit.vim
@@ -182,4 +182,3 @@ function! s:_switch(path) abort
   endif
   return bufnr('%')
 endfunction
-

--- a/autoload/vital/_vsnip/VS/Vim/Buffer.vim
+++ b/autoload/vital/_vsnip/VS/Vim/Buffer.vim
@@ -137,4 +137,3 @@ function! s:pseudo(filepath) abort
   augroup END
   return l:bufnr
 endfunction
-

--- a/autoload/vital/_vsnip/VS/Vim/Option.vim
+++ b/autoload/vital/_vsnip/VS/Vim/Option.vim
@@ -18,4 +18,3 @@ function! s:define(map) abort
   endfor
   return { -> s:define(l:old) }
 endfunction
-

--- a/autoload/vsnip/indent.vim
+++ b/autoload/vsnip/indent.vim
@@ -58,4 +58,3 @@ function! vsnip#indent#trim_base_indent(text) abort
   endfor
   return substitute(l:text, "\\%(^\\|\n\\)\\zs\\V" . l:base_indent, '', 'g')
 endfunction
-

--- a/autoload/vsnip/parser/combinator.vim
+++ b/autoload/vsnip/parser/combinator.vim
@@ -220,4 +220,3 @@ function! s:getchar(text, pos) abort
   endif
   return ''
 endfunction
-

--- a/autoload/vsnip/range.vim
+++ b/autoload/vsnip/range.vim
@@ -7,4 +7,3 @@ function! vsnip#range#cover(whole_range, target_range) abort
   let l:cover = l:cover && (a:target_range.end.line < a:whole_range.end.line || a:target_range.end.line == a:whole_range.end.line && a:target_range.end.character <= a:whole_range.end.character)
   return l:cover
 endfunction
-

--- a/autoload/vsnip/session.vim
+++ b/autoload/vsnip/session.vim
@@ -257,4 +257,3 @@ function! s:Session.store(changenr) abort
   \ }
   let self.changenr = a:changenr
 endfunction
-

--- a/autoload/vsnip/snippet/node/transform.vim
+++ b/autoload/vsnip/snippet/node/transform.vim
@@ -36,7 +36,7 @@ function! s:Transform.text(input_text) abort
   endif
 
   let l:text = ''
- 
+
   for l:replacement in self.replacements
     if l:replacement.type ==# 'format'
       if l:replacement.modifier ==# '/capitalize'

--- a/autoload/vsnip/snippet/node/variable.vim
+++ b/autoload/vsnip/snippet/node/variable.vim
@@ -60,4 +60,3 @@ function! s:Variable.to_string() abort
   \   self.text()
   \ )
 endfunction
-

--- a/autoload/vsnip/snippet/parser.vim
+++ b/autoload/vsnip/snippet/parser.vim
@@ -5,15 +5,15 @@ let s:Combinator = vsnip#parser#combinator#import()
 " @see https://github.com/Microsoft/language-server-protocol/blob/master/snippetSyntax.md
 "
 function! vsnip#snippet#parser#parse(text) abort
-	if strlen(a:text) == 0
-		return []
-	endif
+  if strlen(a:text) == 0
+    return []
+  endif
 
-	let l:parsed = s:parser.parse(a:text, 0)
-	if !l:parsed[0]
-		throw json_encode({ 'text': a:text, 'result': l:parsed })
-	endif
-	return l:parsed[1]
+  let l:parsed = s:parser.parse(a:text, 0)
+  if !l:parsed[0]
+    throw json_encode({ 'text': a:text, 'result': l:parsed })
+  endif
+  return l:parsed[1]
 endfunction
 
 let s:skip = s:Combinator.skip
@@ -209,4 +209,3 @@ let s:choice = s:map(s:seq(
 " parser.
 "
 let s:parser = s:many(s:or(s:any, s:text(['$'], ['}'])))
-

--- a/autoload/vsnip/source.vim
+++ b/autoload/vsnip/source.vim
@@ -23,13 +23,7 @@ endfunction
 "
 function! vsnip#source#filetypes( bufnr ) abort
   if has( "nvim" )
-    let g:vsnip_treesitter_bufnr = a:bufnr
-
-    lua << EOF
-      vim.g.vsnip_treesitter_bufnr_filetype = require( "vsnip/treesitter" ).get_ft_at_cursor( vim.g.vsnip_treesitter_bufnr )
-EOF
-
-    let l:filetype = g:vsnip_treesitter_bufnr_filetype
+    let l:filetype = v:lua.require'vsnip.treesitter'.get_ft_at_cursor( a:bufnr )
   else
     let l:filetype = getbufvar( a:bufnr, "&filetype", "" )
   endif

--- a/autoload/vsnip/source.vim
+++ b/autoload/vsnip/source.vim
@@ -22,7 +22,7 @@ endfunction
 " vsnip#source#filetypes
 "
 function! vsnip#source#filetypes( bufnr ) abort
-	if has( "nvim" )
+  if has( "nvim" )
     let g:vsnip_treesitter_bufnr = a:bufnr
 
     lua << EOF
@@ -30,7 +30,7 @@ function! vsnip#source#filetypes( bufnr ) abort
 EOF
 
     let l:filetype = g:vsnip_treesitter_bufnr_filetype
-	else
+  else
     let l:filetype = getbufvar( a:bufnr, "&filetype", "" )
   endif
 
@@ -124,4 +124,3 @@ function! vsnip#source#resolve_prefix(prefix) abort
   \   sort(l:prefixes_alias, { a, b -> strlen(b) - strlen(a) })
   \ ]
 endfunction
-

--- a/autoload/vsnip/source.vim
+++ b/autoload/vsnip/source.vim
@@ -21,9 +21,20 @@ endfunction
 "
 " vsnip#source#filetypes
 "
-function! vsnip#source#filetypes(bufnr) abort
-  let l:filetype = getbufvar(a:bufnr, '&filetype', '')
-  return split(l:filetype, '\.') + get(g:vsnip_filetypes, l:filetype, []) + ['global']
+function! vsnip#source#filetypes( bufnr ) abort
+	if has( "nvim" )
+    let g:vsnip_treesitter_bufnr = a:bufnr
+
+    lua << EOF
+      vim.g.vsnip_treesitter_bufnr_filetype = require( "vsnip/treesitter" ).get_ft_at_cursor( vim.g.vsnip_treesitter_bufnr )
+EOF
+
+    let l:filetype = g:vsnip_treesitter_bufnr_filetype
+	else
+    let l:filetype = getbufvar( a:bufnr, "&filetype", "" )
+  endif
+
+  return split( l:filetype, '\.' ) + get( g:vsnip_filetypes, l:filetype, [] ) + [ "global" ]
 endfunction
 
 "

--- a/autoload/vsnip/source/user_snippet.vim
+++ b/autoload/vsnip/source/user_snippet.vim
@@ -66,4 +66,3 @@ endfun
 fun! vsnip#source#user_snippet#paths(...) abort
   return s:get_source_paths(a:0 ? a:1 : bufnr(''))
 endfun
-

--- a/autoload/vsnip/source/vscode.vim
+++ b/autoload/vsnip/source/vscode.vim
@@ -101,4 +101,3 @@ function! s:get_language(filetype) abort
   \   'cs': 'csharp',
   \ }, a:filetype, a:filetype)
 endfunction
-

--- a/autoload/vsnip/variable.vim
+++ b/autoload/vsnip/variable.vim
@@ -186,4 +186,3 @@ function! s:VSNIP_CAMELCASE_FILENAME(context) abort
   return substitute(l:basename, '\(\%(\<\l\+\)\%(_\)\@=\)\|_\(\l\)', '\u\1\2', 'g')
 endfunction
 call vsnip#variable#register('VSNIP_CAMELCASE_FILENAME', function('s:VSNIP_CAMELCASE_FILENAME'))
-

--- a/lua/vsnip/treesitter.lua
+++ b/lua/vsnip/treesitter.lua
@@ -1,0 +1,34 @@
+local M = {}
+
+local ok_parsers, ts_parsers = pcall( require, "nvim-treesitter.parsers" )
+if not ok_parsers then
+  ts_parsers = nil
+end
+
+local ok_utils, ts_utils = pcall( require, "nvim-treesitter.ts_utils" )
+if not ok_utils then
+  ts_utils = nil
+end
+
+function M.is_available ()
+  return ok_parsers and ok_utils
+end
+
+function M.get_ft_at_cursor ( bufnr )
+  if M.is_available() then
+    local cur_node = ts_utils.get_node_at_cursor( vim.fn.bufwinid( bufnr ) )
+
+    if cur_node then
+      local parser = ts_parsers.get_parser( bufnr )
+      local lang = parser:language_for_range( { cur_node:range() } ):lang()
+
+      if ts_parsers.list[ lang ] ~= nil then
+        return ts_parsers.list[ lang ].filetype or lang
+      end
+    end
+  end
+
+  return vim.bo[ bufnr ].filetype or ""
+end
+
+return M

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/hrsh7th/vim-test-snips#readme",
   "devDependencies": {
-    "husky": "^3.0.5",
+    "husky": "^5.0.0",
     "npm-run-all": "^4.1.5",
     "watch": "^1.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/hrsh7th/vim-test-snips#readme",
   "devDependencies": {
-    "husky": "^5.0.0",
+    "husky": "^9.0.0",
     "npm-run-all": "^4.1.5",
     "watch": "^1.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,16 @@
   "name": "vim-vsnip",
   "version": "1.0.0",
   "description": "This aims to plugin like Visual Studio Code's Snippet feature.",
+  "homepage": "https://github.com/hrsh7th/vim-test-snips#readme",
+  "bugs": {
+    "url": "https://github.com/hrsh7th/vim-test-snips/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hrsh7th/vim-test-snips.git"
+  },
+  "license": "MIT",
+  "author": "hrsh7th",
   "scripts": {
     "open": "nvim -u .vimrc",
     "test": "run-s test:*",
@@ -20,16 +30,6 @@
       "pre-commit": "npm run lint && npm run test"
     }
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/hrsh7th/vim-test-snips.git"
-  },
-  "author": "hrsh7th",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/hrsh7th/vim-test-snips/issues"
-  },
-  "homepage": "https://github.com/hrsh7th/vim-test-snips#readme",
   "devDependencies": {
     "husky": "^9.0.0",
     "npm-run-all": "^4.1.5",

--- a/plugin/vsnip.vim
+++ b/plugin/vsnip.vim
@@ -222,4 +222,3 @@ endfunction
 function! s:on_buf_write_post() abort
   call vsnip#source#refresh(resolve(fnamemodify(bufname('%'), ':p')))
 endfunction
-


### PR DESCRIPTION
This patch adds `treesitter` support.
It replaces standard behavior under `nvim` and if `nvim-treesitter` is installed.
It returns filetype for the code under the cursor, so embedded code is also processes correctly.