### PR TITLE
Refactor treesitter filetype detection

### DIFF
--- a/autoload/vsnip/source.vim
+++ b/autoload/vsnip/source.vim
@@ -23,12 +23,25 @@ endfunction
 "
 function! vsnip#source#filetypes( bufnr ) abort
   if has( "nvim" )
-    let l:filetype = v:lua.require'vsnip.treesitter'.get_ft_at_cursor( a:bufnr )
+    let l:filetypes = v:lua.require'vsnip.treesitter'.get_ft_at_cursor( a:bufnr )
+
+    if l:filetypes.filetype == ""
+      return [ "global" ]
+    else
+      return get(
+        \ g:vsnip_filetypes, l:filetypes.injected_filetype,
+        \ get( g:vsnip_filetypes, l:filetypes.filetype,
+        \ [ l:filetypes.filetype ]
+        \ ) )
+        \ + [ "global" ]
+    endif
   else
     let l:filetype = getbufvar( a:bufnr, "&filetype", "" )
-  endif
 
-  return split( l:filetype, '\.' ) + get( g:vsnip_filetypes, l:filetype, [] ) + [ "global" ]
+    " FIXME: split( l:filetype, '\.' ) - does it has any sense, can buffer filetype contain "." character?
+    " return split( l:filetype, '\.' ) + get( g:vsnip_filetypes, l:filetype, [] ) + [ "global" ]
+    return [ l:filetype ] + get( g:vsnip_filetypes, l:filetype, [] ) + [ "global" ]
+  endif
 endfunction
 
 "

--- a/autoload/vsnip/source.vim
+++ b/autoload/vsnip/source.vim
@@ -41,9 +41,7 @@ function! vsnip#source#filetypes( bufnr ) abort
   else
     let l:filetype = getbufvar( a:bufnr, "&filetype", "" )
 
-    " FIXME: split( l:filetype, '\.' ) - does it has any sense, can buffer filetype contain "." character?
-    " return split( l:filetype, '\.' ) + get( g:vsnip_filetypes, l:filetype, [] ) + [ "global" ]
-    return [ l:filetype ] + get( g:vsnip_filetypes, l:filetype, [] ) + [ "global" ]
+    return split( l:filetype, '\.' ) + get( g:vsnip_filetypes, l:filetype, [] ) + [ "global" ]
   endif
 endfunction
 

--- a/autoload/vsnip/source.vim
+++ b/autoload/vsnip/source.vim
@@ -25,11 +25,14 @@ function! vsnip#source#filetypes( bufnr ) abort
   if has( "nvim" )
     let l:filetypes = v:lua.require'vsnip.treesitter'.get_ft_at_cursor( a:bufnr )
 
+    " buffer has no filetype defined
     if l:filetypes.filetype == ""
       return [ "global" ]
+
+    " buffer has filetype
     else
-      return get(
-        \ g:vsnip_filetypes, l:filetypes.injected_filetype,
+      return
+        \ get( g:vsnip_filetypes, l:filetypes.injected_filetype,
         \ get( g:vsnip_filetypes, l:filetypes.filetype,
         \ [ l:filetypes.filetype ]
         \ ) )

--- a/doc/vsnip.txt
+++ b/doc/vsnip.txt
@@ -78,7 +78,7 @@ VARIABLE                                                      *vsnip-variable*
 >
     let g:vsnip_filetypes['vim/lua'] = ['lua', 'vim/lua']
     let g:vsnip_filetypes['vue'] = ['html']
-    let g:vsnip_filetypes['vim/javascript'] = ['javascript', 'vue/javascript']
+    let g:vsnip_filetypes['vue/javascript'] = ['javascript', 'vue/javascript']
 <
 
  let g:vsnip_deactivate_on = g:vsnip#DeactivateOn.OutsideOfSnippet~

--- a/doc/vsnip.txt
+++ b/doc/vsnip.txt
@@ -71,6 +71,16 @@ VARIABLE                                                      *vsnip-variable*
       let g:vsnip_filetypes = {}
       let g:vsnip_filetypes.javascriptreact = ['javascript']
 <
+
+    If you are using `treesitter` you can define snippets for injected
+    languages like this:
+
+>
+    let g:vsnip_filetypes['vim/lua'] = ['lua', 'vim/lua']
+    let g:vsnip_filetypes['vue'] = ['html']
+    let g:vsnip_filetypes['vim/javascript'] = ['javascript', 'vue/javascript']
+<
+
  let g:vsnip_deactivate_on = g:vsnip#DeactivateOn.OutsideOfSnippet~
     Specify when to deactivate the current snippet.
 

--- a/doc/vsnip.txt
+++ b/doc/vsnip.txt
@@ -76,9 +76,9 @@ VARIABLE                                                      *vsnip-variable*
     languages like this:
 
 >
-    let g:vsnip_filetypes['vim.lua'] = ['lua', 'vim/lua']
+    let g:vsnip_filetypes['vim/lua'] = ['lua', 'vim/lua']
     let g:vsnip_filetypes['vue'] = ['html']
-    let g:vsnip_filetypes['vim.javascript'] = ['javascript', 'vue/javascript']
+    let g:vsnip_filetypes['vim/javascript'] = ['javascript', 'vue/javascript']
 <
 
  let g:vsnip_deactivate_on = g:vsnip#DeactivateOn.OutsideOfSnippet~

--- a/doc/vsnip.txt
+++ b/doc/vsnip.txt
@@ -76,9 +76,9 @@ VARIABLE                                                      *vsnip-variable*
     languages like this:
 
 >
-    let g:vsnip_filetypes['vim/lua'] = ['lua', 'vim/lua']
+    let g:vsnip_filetypes['vim.lua'] = ['lua', 'vim/lua']
     let g:vsnip_filetypes['vue'] = ['html']
-    let g:vsnip_filetypes['vim/javascript'] = ['javascript', 'vue/javascript']
+    let g:vsnip_filetypes['vim.javascript'] = ['javascript', 'vue/javascript']
 <
 
  let g:vsnip_deactivate_on = g:vsnip#DeactivateOn.OutsideOfSnippet~

--- a/lua/vsnip/treesitter.lua
+++ b/lua/vsnip/treesitter.lua
@@ -28,29 +28,22 @@ function M.get_ft_at_cursor ( bufnr )
 
     if cur_node then
       local parser = ts_parsers.get_parser( bufnr )
-      local lang = parser:language_for_range( { cur_node:range() } ):lang()
+      local language_tree_at_cursor = parser:language_for_range( { cur_node:range() } )
+      local language_at_cursor = language_tree_at_cursor:lang()
 
-      local filetype = get_parser_filetype( lang )
+      local filetype = get_parser_filetype( language_at_cursor )
 
       if filetype ~= "" then
+        local parent_language_tree = language_tree_at_cursor:parent()
 
-        -- XXX: not works
-        local parent_parser = parser:parent()
+        if parent_language_tree then
+          local parent_language = parent_language_tree:lang()
+          local parent_filetype = get_parser_filetype( parent_language )
 
-        if parent_parser then
-          local parent_lang = parent_parser:lang()
-
-          if parent_lang and parent_lang ~= filetype then
-            local parent_filetype = get_parser_filetype( parent_lang )
-
-            if parent_filetype ~= "" then
-              filetype = filetype .. "." .. parent_filetype .. "/" .. filetype
-            end
+          if parent_filetype ~= "" and parent_filetype ~= filetype then
+            filetype = filetype .. "." .. parent_filetype .. "/" .. filetype
           end
         end
-
-        -- XXX
-        vim.print( "--- " .. filetype )
 
         return filetype
       end

--- a/lua/vsnip/treesitter.lua
+++ b/lua/vsnip/treesitter.lua
@@ -23,6 +23,11 @@ function M.is_available ()
 end
 
 function M.get_ft_at_cursor ( bufnr )
+  local filetypes = {
+    filetype = "",
+    injected_filetype = "",
+  }
+
   if M.is_available() then
     local cur_node = ts_utils.get_node_at_cursor( vim.fn.bufwinid( bufnr ) )
 
@@ -34,6 +39,8 @@ function M.get_ft_at_cursor ( bufnr )
       local filetype = get_parser_filetype( language_at_cursor )
 
       if filetype ~= "" then
+        filetypes.filetype = filetype
+
         local parent_language_tree = language_tree_at_cursor:parent()
 
         if parent_language_tree then
@@ -41,16 +48,18 @@ function M.get_ft_at_cursor ( bufnr )
           local parent_filetype = get_parser_filetype( parent_language )
 
           if parent_filetype ~= "" then
-            filetype = filetype .. "." .. parent_filetype .. "/" .. filetype
+            filetypes.injected_filetype = parent_filetype .. "/" .. filetype
           end
         end
 
-        return filetype
+        return filetypes
       end
     end
   end
 
-  return vim.bo[ bufnr ].filetype or ""
+  filetypes.filetype = vim.bo[ bufnr ].filetype or ""
+
+  return filetypes
 end
 
 return M

--- a/lua/vsnip/treesitter.lua
+++ b/lua/vsnip/treesitter.lua
@@ -48,7 +48,7 @@ function M.get_ft_at_cursor ( bufnr )
           local parent_filetype = get_parser_filetype( parent_language )
 
           if parent_filetype ~= "" then
-            filetypes.injected_filetype = parent_filetype .. "/" .. filetype
+            filetypes.injected_filetype = parent_filetype .. "." .. filetype
           end
         end
 

--- a/lua/vsnip/treesitter.lua
+++ b/lua/vsnip/treesitter.lua
@@ -40,7 +40,7 @@ function M.get_ft_at_cursor ( bufnr )
           local parent_language = parent_language_tree:lang()
           local parent_filetype = get_parser_filetype( parent_language )
 
-          if parent_filetype ~= "" and parent_filetype ~= filetype then
+          if parent_filetype ~= "" then
             filetype = filetype .. "." .. parent_filetype .. "/" .. filetype
           end
         end

--- a/lua/vsnip/treesitter.lua
+++ b/lua/vsnip/treesitter.lua
@@ -48,7 +48,7 @@ function M.get_ft_at_cursor ( bufnr )
           local parent_filetype = get_parser_filetype( parent_language )
 
           if parent_filetype ~= "" then
-            filetypes.injected_filetype = parent_filetype .. "." .. filetype
+            filetypes.injected_filetype = parent_filetype .. "/" .. filetype
           end
         end
 

--- a/lua/vsnip/treesitter.lua
+++ b/lua/vsnip/treesitter.lua
@@ -10,6 +10,14 @@ if not ok_utils then
   ts_utils = nil
 end
 
+local function get_parser_filetype ( lang )
+  if lang and ts_parsers.list[ lang ] then
+    return ts_parsers.list[ lang ].filetype or lang
+  else
+    return ""
+  end
+end
+
 function M.is_available ()
   return ok_parsers and ok_utils
 end
@@ -22,8 +30,29 @@ function M.get_ft_at_cursor ( bufnr )
       local parser = ts_parsers.get_parser( bufnr )
       local lang = parser:language_for_range( { cur_node:range() } ):lang()
 
-      if ts_parsers.list[ lang ] ~= nil then
-        return ts_parsers.list[ lang ].filetype or lang
+      local filetype = get_parser_filetype( lang )
+
+      if filetype ~= "" then
+
+        -- XXX: not works
+        local parent_parser = parser:parent()
+
+        if parent_parser then
+          local parent_lang = parent_parser:lang()
+
+          if parent_lang and parent_lang ~= filetype then
+            local parent_filetype = get_parser_filetype( parent_lang )
+
+            if parent_filetype ~= "" then
+              filetype = filetype .. "." .. parent_filetype .. "/" .. filetype
+            end
+          end
+        end
+
+        -- XXX
+        vim.print( "--- " .. filetype )
+
+        return filetype
       end
     end
   end

--- a/lua/vsnip/treesitter.lua
+++ b/lua/vsnip/treesitter.lua
@@ -18,7 +18,7 @@ local function get_parser_filetype ( lang )
   end
 end
 
-function M.is_available ()
+local function is_available ()
   return ok_parsers and ok_utils
 end
 
@@ -28,7 +28,7 @@ function M.get_ft_at_cursor ( bufnr )
     injected_filetype = "",
   }
 
-  if M.is_available() then
+  if is_available() then
     local cur_node = ts_utils.get_node_at_cursor( vim.fn.bufwinid( bufnr ) )
 
     if cur_node then


### PR DESCRIPTION
This patch allows to flexibly define snippets for injected languages.
Now `treesitter` filetype detector returns two filetypes:
1. filetype for code under the cutsor;
2. combined filetype for code under the cursor + parent code block (for injected language);

For example, for `lua` injected into `vim` script it will retirn:

```lua
{
    filetype = "lua",
    injected_filetype = "vim/lua",
}
```

This will allow users to configure snippets more flexibly. For example, if I want to add some snippets for `lua` code, injected into `vim`, for example  `vim.print( $1 )`, I will need to setup filetypes mapping like this:

```lua
vim.g.vsnip_filetypes = {
    [ "vim/lua" ] = { "lua", "vim/lua" },
}
```
So for regular `lua` script `lua.json` snippets will be used, and for injected `vim/lua` - `lua.json` and `vim/lua.json`.